### PR TITLE
remove StartKUDO reference

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -33,8 +33,6 @@ type TestSuite struct {
 	KINDNodeCache bool `json:"kindNodeCache"`
 	// Containers to load to each KIND node prior to running the tests.
 	KINDContainers []string `json:"kindContainers"`
-	// Whether or not to start the KUDO controller for the tests.
-	StartKUDO bool `json:"startKUDO"`
 	// If set, do not delete the resources after running the tests (implies SkipClusterDelete).
 	SkipDelete bool `json:"skipDelete"`
 	// If set, do not delete the mocked control plane or kind cluster.

--- a/pkg/test/harness_integration_test.go
+++ b/pkg/test/harness_integration_test.go
@@ -14,7 +14,6 @@ func TestHarnessRunIntegration(t *testing.T) {
 			TestDirs: []string{
 				"./test_data/",
 			},
-			StartKUDO:         false,
 			StartControlPlane: true,
 		},
 		T: t,


### PR DESCRIPTION
this PR removes the StartKUDO from the struct as described in
Issue #9 .

closes #9 