### PR TITLE
Support Background Processes

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -104,6 +104,8 @@ type Command struct {
 	Namespaced bool `json:"namespaced"`
 	// If set, failures will be ignored.
 	IgnoreFailure bool `json:"ignoreFailure"`
+	// If set, the command is run in the background.
+	Background bool `json:"background"`
 }
 
 // DefaultKINDContext defines the default kind context to use.

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -33,8 +33,6 @@ type TestSuite struct {
 	KINDNodeCache bool `json:"kindNodeCache"`
 	// Containers to load to each KIND node prior to running the tests.
 	KINDContainers []string `json:"kindContainers"`
-	// Whether or not to start the KUDO controller for the tests.
-	StartKUDO bool `json:"startKUDO"`
 	// If set, do not delete the resources after running the tests (implies SkipClusterDelete).
 	SkipDelete bool `json:"skipDelete"`
 	// If set, do not delete the mocked control plane or kind cluster.

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -102,7 +102,7 @@ type Command struct {
 	Command string `json:"command"`
 	// If set, the `--namespace` flag will be appended to the command with the namespace to use.
 	Namespaced bool `json:"namespaced"`
-	// If set, failures will be ignored.
+	// If set, exit failures (`exec.ExitError`) will be ignored. `exec.Error` are NOT ignored.
 	IgnoreFailure bool `json:"ignoreFailure"`
 	// If set, the command is run in the background.
 	Background bool `json:"background"`

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -43,6 +44,8 @@ type Harness struct {
 	kubeConfigPath string
 	clientLock     sync.Mutex
 	configLock     sync.Mutex
+	stopping       bool
+	bgProcesses    []*exec.Cmd
 }
 
 // LoadTests loads all of the tests in a given directory.
@@ -60,7 +63,7 @@ func (h *Harness) LoadTests(dir string) ([]*Case, error) {
 	tests := []*Case{}
 
 	timeout := h.GetTimeout()
-	h.T.Logf("Going to run test suite with timeout of %d seconds for each step", timeout)
+	h.T.Logf("going to run test suite with timeout of %d seconds for each step", timeout)
 
 	for _, file := range files {
 		if !file.IsDir() {
@@ -207,13 +210,13 @@ func (h *Harness) Config() (*rest.Config, error) {
 	var err error
 
 	if h.TestSuite.StartControlPlane {
-		h.T.Log("Running tests with a mocked control plane (kube-apiserver and etcd).")
+		h.T.Log("running tests with a mocked control plane (kube-apiserver and etcd).")
 		h.config, err = h.RunTestEnv()
 	} else if h.TestSuite.StartKIND {
-		h.T.Log("Running tests with KIND.")
+		h.T.Log("running tests with KIND.")
 		h.config, err = h.RunKIND()
 	} else {
-		h.T.Log("Running tests using configured kubeconfig.")
+		h.T.Log("running tests using configured kubeconfig.")
 		h.config, err = config.GetConfig()
 	}
 
@@ -283,7 +286,9 @@ func (h *Harness) DockerClient() (testutils.DockerClient, error) {
 // RunTests should be called from within a Go test (t) and launches all of the KUDO integration
 // tests at dir.
 func (h *Harness) RunTests() {
-	h.T.Log("Running tests")
+	// cleanup after running tests
+	defer h.Stop()
+	h.T.Log("running tests")
 	tests := []*Case{}
 
 	for _, testDir := range h.TestSuite.TestDirs {
@@ -324,53 +329,54 @@ func (h *Harness) Run() {
 // It can be used to start env which can than be modified prior to running tests, otherwise use Run().
 func (h *Harness) Setup() {
 	rand.Seed(time.Now().UTC().UnixNano())
-	h.T.Log("Starting Setup")
-	defer h.Stop()
+	h.T.Log("starting setup")
 
 	cl, err := h.Client(false)
 	if err != nil {
-		h.T.Fatal(err)
+		h.fatal(err)
 	}
 
 	dClient, err := h.DiscoveryClient()
 	if err != nil {
-		h.T.Fatal(err)
+		h.fatal(err)
 	}
 
 	// Install CRDs
 	crdKind := testutils.NewResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "", "")
 	crds, err := testutils.InstallManifests(context.TODO(), cl, dClient, h.TestSuite.CRDDir, crdKind)
 	if err != nil {
-		h.T.Fatal(err)
+		h.fatal(err)
 	}
 
 	if err := testutils.WaitForCRDs(dClient, crds); err != nil {
-		h.T.Fatal(err)
+		h.fatal(err)
 	}
 
 	// Create a new client to bust the client's CRD cache.
 	cl, err = h.Client(true)
 	if err != nil {
-		h.T.Fatal(err)
+		h.fatal(err)
 	}
 
 	// Install required manifests.
 	for _, manifestDir := range h.TestSuite.ManifestDirs {
 		if _, err := testutils.InstallManifests(context.TODO(), cl, dClient, manifestDir); err != nil {
-			h.T.Fatal(err)
+			h.fatal(err)
 		}
 	}
-
-	if err := testutils.RunCommands(h.GetLogger(), "default", "", h.TestSuite.Commands, ""); err != nil {
-		h.T.Fatal(err)
+	bgs, errs := testutils.RunCommands(h.GetLogger(), "default", "", h.TestSuite.Commands, "")
+	// assign any background processes first for cleanup if err is fatal
+	h.bgProcesses = append(h.bgProcesses, bgs...)
+	if errs != nil {
+		h.fatal(err)
 	}
 
-	if err := testutils.RunKubectlCommands(h.GetLogger(), "default", h.TestSuite.Kubectl, ""); err != nil {
-		h.T.Fatal(err)
+	if errs := testutils.RunKubectlCommands(h.GetLogger(), "default", h.TestSuite.Kubectl, ""); errs != nil {
+		h.fatal(errs)
 	}
 }
 
-// Stop the test environment and KUDO, clean up the harness.
+// Stop the test environment and clean up the harness.
 func (h *Harness) Stop() {
 	if h.managerStopCh != nil {
 		close(h.managerStopCh)
@@ -397,6 +403,15 @@ func (h *Harness) Stop() {
 		return
 	}
 
+	if h.bgProcesses != nil {
+		for _, process := range h.bgProcesses {
+			err := process.Process.Kill()
+			if err != nil {
+				h.T.Log("background process kill error", err)
+			}
+		}
+	}
+
 	if h.env != nil {
 		h.T.Log("tearing down mock control plane")
 		if err := h.env.Stop(); err != nil {
@@ -418,6 +433,17 @@ func (h *Harness) Stop() {
 
 		h.kind = nil
 	}
+}
+
+// wraps Test.Fatal in order to clean up harness
+func (h *Harness) fatal(args ...interface{}) {
+	// clean up on fatal in setup
+	if !h.stopping {
+		// stopping prevents reentry into h.Stop
+		h.stopping = true
+		h.Stop()
+	}
+	h.T.Fatal(args...)
 }
 
 func (h *Harness) explicitPath() string {

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -283,6 +283,7 @@ func (h *Harness) DockerClient() (testutils.DockerClient, error) {
 // RunTests should be called from within a Go test (t) and launches all of the KUDO integration
 // tests at dir.
 func (h *Harness) RunTests() {
+	h.T.Log("Running tests")
 	tests := []*Case{}
 
 	for _, testDir := range h.TestSuite.TestDirs {
@@ -313,11 +314,17 @@ func (h *Harness) RunTests() {
 	})
 }
 
-// Run the test harness - start KUDO and the control plane and install the operators, if necessary
-// and then run the tests.
+// Run the test harness - start KUDO and the control plane and then run the tests.
 func (h *Harness) Run() {
-	rand.Seed(time.Now().UTC().UnixNano())
+	h.Setup()
+	h.RunTests()
+}
 
+// Setup spins up the test env based on configuration
+// It can be used to start env which can than be modified prior to running tests, otherwise use Run().
+func (h *Harness) Setup() {
+	rand.Seed(time.Now().UTC().UnixNano())
+	h.T.Log("Starting Setup")
 	defer h.Stop()
 
 	cl, err := h.Client(false)
@@ -361,8 +368,6 @@ func (h *Harness) Run() {
 	if err := testutils.RunKubectlCommands(h.GetLogger(), "default", h.TestSuite.Kubectl, ""); err != nil {
 		h.T.Fatal(err)
 	}
-
-	h.RunTests()
 }
 
 // Stop the test environment and KUDO, clean up the harness.

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -373,7 +373,13 @@ func (s *Step) Run(namespace string) []error {
 	testErrors := []error{}
 
 	if s.Step != nil {
-		if errors := testutils.RunCommands(s.Logger, namespace, "", s.Step.Commands, s.Dir); errors != nil {
+		for _, command := range s.Step.Commands {
+			if command.Background {
+				s.Logger.Log("background commands are not allowed for steps and will be run in foreground")
+				command.Background = false
+			}
+		}
+		if _, errors := testutils.RunCommands(s.Logger, namespace, "", s.Step.Commands, s.Dir); errors != nil {
 			testErrors = append(testErrors, errors...)
 		}
 

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -955,9 +955,11 @@ func RunCommand(ctx context.Context, namespace string, command string, cmd harne
 		fmt.Sprintf("PATH=%s/bin/:%s", actualDir, os.Getenv("PATH")),
 	}
 
+	// process started and exited with error
+	var exerr *exec.ExitError
 	err = builtCmd.Start()
 	if err != nil {
-		if _, ok := err.(*exec.ExitError); ok && cmd.IgnoreFailure {
+		if errors.As(err, &exerr) && cmd.IgnoreFailure {
 			return nil, nil
 		}
 		return nil, err
@@ -968,7 +970,7 @@ func RunCommand(ctx context.Context, namespace string, command string, cmd harne
 	}
 
 	err = builtCmd.Wait()
-	if _, ok := err.(*exec.ExitError); ok && cmd.IgnoreFailure {
+	if errors.As(err, &exerr) && cmd.IgnoreFailure {
 		return nil, nil
 	}
 	return nil, err

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -946,8 +946,10 @@ func RunCommand(ctx context.Context, namespace string, command string, cmd harne
 	}
 
 	builtCmd.Dir = cwd
-	builtCmd.Stdout = stdout
-	builtCmd.Stderr = stderr
+	if !cmd.Background {
+		builtCmd.Stdout = stdout
+		builtCmd.Stderr = stderr
+	}
 	builtCmd.Env = []string{
 		fmt.Sprintf("KUBECONFIG=%s/kubeconfig", actualDir),
 		fmt.Sprintf("PATH=%s/bin/:%s", actualDir, os.Getenv("PATH")),
@@ -992,7 +994,9 @@ func RunCommands(logger Logger, namespace string, command string, commands []har
 		bg, err := RunCommand(context.TODO(), namespace, command, cmd, workdir, stdout, stderr)
 		if err != nil {
 			errs = append(errs, err)
-			bgs = append(bgs, bg)
+			if bg != nil {
+				bgs = append(bgs, bg)
+			}
 		}
 
 		logger.Log(stderr.String())


### PR DESCRIPTION
In order to support different ways to add a controller under test, we are adding support for running background processes.   This will add the ability to configure something like:

```
commands:
  - command: ./bin/manager 
```
which will run a controller in the background for testing