### PR TITLE
remove default ns for kubectl commands

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -371,7 +371,7 @@ func (h *Harness) Setup() {
 		h.fatal(errs)
 	}
 
-	if errs := testutils.RunKubectlCommands(h.GetLogger(), "default", h.TestSuite.Kubectl, ""); errs != nil {
+	if errs := testutils.RunKubectlCommands(h.GetLogger(), "", h.TestSuite.Kubectl, ""); errs != nil {
 		h.fatal(errs)
 	}
 }

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -920,7 +920,7 @@ func GetArgs(ctx context.Context, command string, cmd harness.Command, namespace
 			return nil, err
 		}
 
-		if *namespaceParsed == "" {
+		if *namespaceParsed == "" && namespace != "" {
 			argSlice = append(argSlice, "--namespace", namespace)
 		}
 	}

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -404,6 +404,14 @@ func TestGetKubectlArgs(t *testing.T) {
 				"kubectl", "kudo", "test", "--namespace", "default",
 			},
 		},
+		{
+			testName:  "namespace not present isn't appended",
+			namespace: "",
+			args:      "kubectl kudo test",
+			expected: []string{
+				"kubectl", "kudo", "test",
+			},
+		},
 	} {
 		test := test
 


### PR DESCRIPTION
I have a use case where I need to create resources from a yaml file and those resources belong to different namespaces. So I cannot use `--namespace` flag. But defaulting to `default` flag also doesn't work in this case

Example:
```
apiVersion: kudo.dev/v1alpha1
kind: TestSuite
kubectl:
- apply -f https://mesosphere.github.io/kubeaddons/bundle.yaml
testDirs:
- ./repository/zookeeper/tests
startKIND: true
startKUDO: false
timeout: 300
```
this ends up with errors:
```
the namespace from the provided object "kubeaddons" does not match the namespace "default". You must pass '--namespace=kubeaddons' to perform this operation.
the namespace from the provided object "kubeaddons" does not match the namespace "default". You must pass '--namespace=kubeaddons' to perform this operation.
the namespace from the provided object "kube-system" does not match the namespace "default". You must pass '--namespace=kube-system' to perform this operation.
```

I think we should use namespaces for test cases but we shouldn't use the `default` namespace for the `kubectl commands`. Instead, ask the user to define it through a `--namespace` flag or use the one defined in the definition of the objects in yaml files. 

Signed-off-by: Zain Malik <zmalikshxil@gmail.com>