### PR TITLE
Log output of background commands.

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -961,10 +961,8 @@ func RunCommand(ctx context.Context, namespace string, command string, cmd harne
 	}
 
 	builtCmd.Dir = cwd
-	if !cmd.Background {
-		builtCmd.Stdout = stdout
-		builtCmd.Stderr = stderr
-	}
+	builtCmd.Stdout = stdout
+	builtCmd.Stderr = stderr
 	builtCmd.Env = []string{
 		fmt.Sprintf("KUBECONFIG=%s/kubeconfig", actualDir),
 		fmt.Sprintf("PATH=%s/bin/:%s", actualDir, os.Getenv("PATH")),
@@ -1003,20 +1001,14 @@ func RunCommands(logger Logger, namespace string, command string, commands []har
 	}
 
 	for _, cmd := range commands {
-		stdout := &bytes.Buffer{}
-		stderr := &bytes.Buffer{}
-
 		logger.Logf("running command: %s %s", command, cmd)
 
-		bg, err := RunCommand(context.TODO(), namespace, command, cmd, workdir, stdout, stderr)
+		bg, err := RunCommand(context.TODO(), namespace, command, cmd, workdir, logger, logger)
 		if err != nil {
 			errs = append(errs, err)
 		}
 		if bg != nil {
 			bgs = append(bgs, bg)
-		} else {
-			logger.Log(stderr.String())
-			logger.Log(stdout.String())
 		}
 	}
 

--- a/pkg/test/utils/logger.go
+++ b/pkg/test/utils/logger.go
@@ -27,9 +27,9 @@ type TestLogger struct {
 // NewTestLogger creates a new test logger.
 func NewTestLogger(test *testing.T, prefix string) *TestLogger {
 	return &TestLogger{
-		prefix:  prefix,
-		test:    test,
-		buffer:  []byte{},
+		prefix: prefix,
+		test:   test,
+		buffer: []byte{},
 	}
 }
 


### PR DESCRIPTION
We add a Write() method to the Logger interface to implement the
io.Writer interface and then the logger is passed to the commands as
stdout/stderr.

Signed-off-by: jbarrick@mesosphere.com <jbarrick@mesosphere.com>