### PR TITLE
Test Clean up

### DIFF
--- a/pkg/test/harness_integration_test.go
+++ b/pkg/test/harness_integration_test.go
@@ -3,7 +3,10 @@
 package test
 
 import (
+	"syscall"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	harness "github.com/kudobuilder/kuttl/pkg/apis/testharness/v1beta1"
 )
@@ -19,4 +22,29 @@ func TestHarnessRunIntegration(t *testing.T) {
 		T: t,
 	}
 	harness.Run()
+}
+
+// This test requires external KinD support to run thus is an integration test
+func TestRunBackgroundCommands(t *testing.T) {
+	h := Harness{
+		T: t,
+	}
+	h.TestSuite.StartControlPlane = true
+	commands := []harness.Command{{
+		Command:    "sleep 1000000",
+		Background: true,
+	}}
+	h.TestSuite.Commands = commands
+
+	h.Setup()
+	defer h.Stop()
+
+	// setup creates bg processes
+	assert.Equal(t, 1, len(h.bgProcesses))
+	// process is alive
+	assert.NoError(t, h.bgProcesses[0].Process.Signal(syscall.Signal(0)))
+
+	// cleans up bg processes
+	h.Stop()
+	assert.Error(t, h.bgProcesses[0].Process.Signal(syscall.Signal(0)))
 }

--- a/pkg/test/harness_test.go
+++ b/pkg/test/harness_test.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"syscall"
 	"testing"
 
 	dockertypes "github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/stretchr/testify/assert"
 	kindConfig "sigs.k8s.io/kind/pkg/apis/config/v1alpha3"
-
-	"github.com/kudobuilder/kuttl/pkg/apis/testharness/v1beta1"
 )
 
 func TestGetTimeout(t *testing.T) {
@@ -83,28 +80,4 @@ func TestAddNodeCaches(t *testing.T) {
 	assert.Equal(t, "/var/lib/containerd", kindCfg.Nodes[0].ExtraMounts[0].ContainerPath)
 	assert.Equal(t, "/var/lib/docker/data/kind-0", kindCfg.Nodes[0].ExtraMounts[0].HostPath)
 	assert.Equal(t, "/var/lib/docker/data/kind-1", kindCfg.Nodes[1].ExtraMounts[0].HostPath)
-}
-
-func TestRunBackgroundCommands(t *testing.T) {
-	h := Harness{
-		T: t,
-	}
-	h.TestSuite.StartControlPlane = true
-	commands := []v1beta1.Command{{
-		Command:    "sleep 1000000",
-		Background: true,
-	}}
-	h.TestSuite.Commands = commands
-
-	h.Setup()
-	defer h.Stop()
-
-	// setup creates bg processes
-	assert.Equal(t, 1, len(h.bgProcesses))
-	// process is alive
-	assert.NoError(t, h.bgProcesses[0].Process.Signal(syscall.Signal(0)))
-
-	// cleans up bg processes
-	h.Stop()
-	assert.Error(t, h.bgProcesses[0].Process.Signal(syscall.Signal(0)))
 }

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -133,7 +134,7 @@ func TestRunCommand(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, cmd)
 	// no stdout for background processes
-	assert.Empty(t, stdout)
+	assert.Empty(t, strings.TrimSpace(stdout.String()))
 }
 
 func TestRunCommandIgnoreErrors(t *testing.T) {


### PR DESCRIPTION
unit tests should not have a need on external services like kind.  
refactored to move from unit to integration

Signed-off-by: Ken Sipe <kensipe@gmail.com>
