### PR TITLE
ENV VAR shell expansion to KUTTL commands

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -912,16 +912,19 @@ func StartTestEnvironment() (env TestEnvironment, err error) {
 }
 
 // GetArgs parses a command line string into its arguments and appends a namespace if it is not already set.
+// provides OS expansion of defined ENV VARs inside args to commands.  The expansion is limited to what is defined on the OS
+// and not variables defined for kuttl tests
 func GetArgs(ctx context.Context, command string, cmd harness.Command, namespace string) (*exec.Cmd, error) {
 	argSlice := []string{}
 
-	argSplit, err := shlex.Split(cmd.Command)
+	c := os.ExpandEnv(cmd.Command)
+	argSplit, err := shlex.Split(c)
 	if err != nil {
 		return nil, err
 	}
 
 	if command != "" && argSplit[0] != command {
-		argSlice = append(argSlice, command)
+		argSlice = append(argSlice, os.ExpandEnv(command))
 	}
 
 	argSlice = append(argSlice, argSplit...)

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -966,10 +966,9 @@ func RunCommand(ctx context.Context, namespace string, command string, cmd harne
 	builtCmd.Dir = cwd
 	builtCmd.Stdout = stdout
 	builtCmd.Stderr = stderr
-	builtCmd.Env = []string{
-		fmt.Sprintf("KUBECONFIG=%s/kubeconfig", actualDir),
-		fmt.Sprintf("PATH=%s/bin/:%s", actualDir, os.Getenv("PATH")),
-	}
+	builtCmd.Env = os.Environ()
+	builtCmd.Env = append(builtCmd.Env, fmt.Sprintf("KUBECONFIG=%s/kubeconfig", actualDir))
+	builtCmd.Env = append(builtCmd.Env, fmt.Sprintf("PATH=%s/bin/:%s", actualDir, os.Getenv("PATH")))
 
 	// process started and exited with error
 	var exerr *exec.ExitError


### PR DESCRIPTION
Looking for input on this!  This specifically solves an issue with D2iQ team where output of a CI build provides the "name" or "version" of an image which is to be used under test.  This seems like an easy solution / use case.

Concerns are that this will lead to less portable KUTTL test scripts where awareness is necessary outside of the test suite.   The consensus between @zmalik and I is that there are different categories of tests (which was true before but was implied).  For instance... there are tests which work under 1 test control plane and not another.   It is also valuable to use KUTTL for setup and variation for Mixed Workload Testing for instance for which these tests are not necessarily designed to be portable to other platform environments.

The Acceptance Criteria used to build feature:

##  Expansion of commands
`VER=0.2.0 kuttl test some/test/folder`

With a TestStep has
```
apiVersion: kudo.dev/v1beta1
kind: TestStep
commands:
  - command: kubectl apply -f ../foo/script-$VER.sh
```

## Script Access to ENV
The last commit adds ability for command script to access ENV VARs

TestStep
```
apiVersion: kudo.dev/v1beta1
kind: TestStep
commands:
  - command: ./example.sh
```

```
#!/bin/bash

echo image is $IMAGE_TAG
```
Allowing for `IMAGE_TAG=foo/0.2.0 kuttl test some/test/folder`

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #71 
