### PR TITLE
advance config for mock controller

### DIFF
--- a/config/example-mock-controller.config
+++ b/config/example-mock-controller.config
@@ -1,0 +1,8 @@
+--etcd-servers={{ if .EtcdURL }}{{ .EtcdURL.String }}{{ end }}
+--cert-dir={{ .CertDir }}
+--insecure-port={{ if .URL }}{{ .URL.Port }}{{ end }}
+--insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}
+--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}
+--admission-control=AlwaysAdmit
+--service-cluster-ip-range=10.0.0.0/24
+--advertise-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -22,6 +22,9 @@ type TestSuite struct {
 	TestDirs []string `json:"testDirs"`
 	// Whether or not to start a local etcd and kubernetes API server for the tests.
 	StartControlPlane bool `json:"startControlPlane"`
+	// ControlPlaneArgs defaults to APIServerDefaultArgs from controller-runtime pkg/internal/testing/integration/internal/apiserver.go
+	// this allows for control over the args, however these are not serialized from a TestSuite.yaml
+	ControlPlaneArgs []string
 	// Whether or not to start a local kind cluster for the tests.
 	StartKIND bool `json:"startKIND"`
 	// Path to the KIND configuration file to use.

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -47,6 +47,7 @@ func newTestCmd() *cobra.Command {
 	skipClusterDelete := false
 	parallel := 0
 	artifactsDir := ""
+	mockControllerFile := ""
 
 	options := harness.TestSuite{}
 
@@ -151,6 +152,17 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 			if len(options.TestDirs) == 0 {
 				return errors.New("no test directories provided, please provide either --config or test directories on the command line")
 			}
+			var APIServerArgs []string
+			var err error
+			if mockControllerFile != "" {
+				APIServerArgs, err = testutils.ReadMockControllerConfig(mockControllerFile)
+			} else {
+				APIServerArgs = testutils.APIServerDefaultArgs
+			}
+			if err != nil {
+				return err
+			}
+			options.ControlPlaneArgs = APIServerArgs
 
 			return nil
 		},
@@ -171,6 +183,7 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 	testCmd.Flags().StringSliceVar(&manifestDirs, "manifest-dir", []string{}, "One or more directories containing manifests to apply before running the tests.")
 	testCmd.Flags().StringVar(&testToRun, "test", "", "If set, the specific test case to run.")
 	testCmd.Flags().BoolVar(&startControlPlane, "start-control-plane", false, "Start a local Kubernetes control plane for the tests (requires etcd and kube-apiserver binaries, cannot be used with --start-kind).")
+	testCmd.Flags().StringVar(&mockControllerFile, "control-plane-config", "", "Path to file to load controller-runtime APIServer configuration arguments (only usedful when --startControlPlane).")
 	testCmd.Flags().BoolVar(&startKIND, "start-kind", false, "Start a KIND cluster for the tests (cannot be used with --start-control-plane).")
 	testCmd.Flags().StringVar(&kindConfig, "kind-config", "", "Specify the KIND configuration file path (implies --start-kind, cannot be used with --start-control-plane).")
 	testCmd.Flags().StringVar(&kindContext, "kind-context", "", "Specify the KIND context name to use (default: kind).")

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -187,7 +187,7 @@ func (h *Harness) addNodeCaches(dockerClient testutils.DockerClient, kindCfg *ki
 func (h *Harness) RunTestEnv() (*rest.Config, error) {
 	started := time.Now()
 
-	testenv, err := testutils.StartTestEnvironment()
+	testenv, err := testutils.StartTestEnvironment(h.TestSuite.ControlPlaneArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -191,7 +192,9 @@ func (h *Harness) RunTestEnv() (*rest.Config, error) {
 		return nil, err
 	}
 
-	h.T.Log("started test environment (kube-apiserver and etcd) in", time.Since(started))
+	h.T.Logf("started test environment (kube-apiserver and etcd) in %v, with following options:\n%s",
+		time.Since(started),
+		strings.Join(testenv.Environment.KubeAPIServerFlags, "\n"))
 	h.env = testenv.Environment
 
 	return testenv.Config, nil

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -29,7 +29,7 @@ var testenv testutils.TestEnvironment
 func TestMain(m *testing.M) {
 	var err error
 
-	testenv, err = testutils.StartTestEnvironment()
+	testenv, err = testutils.StartTestEnvironment(testutils.APIServerDefaultArgs)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -70,7 +70,7 @@ var APIServerDefaultArgs = []string{
 	"--insecure-port={{ if .URL }}{{ .URL.Port }}{{ end }}",
 	"--insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}",
 	"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
-	"--admission-control=AlwaysAdmit",
+	"--disable-admission-plugins=ServiceAccount,NamespaceLifecycle",
 	"--service-cluster-ip-range=10.0.0.0/24",
 }
 
@@ -891,13 +891,7 @@ func StartTestEnvironment() (env TestEnvironment, err error) {
 		KubeAPIServerFlags: append(APIServerDefaultArgs, "--advertise-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}"),
 	}
 
-	// Retry up to three times for the test environment to start up in case there is a port collision (#510).
-	for i := 0; i < 3; i++ {
-		env.Config, err = env.Environment.Start()
-		if err == nil {
-			break
-		}
-	}
+	env.Config, err = env.Environment.Start()
 
 	if err != nil {
 		return
@@ -1004,7 +998,7 @@ func RunCommands(logger Logger, namespace string, command string, commands []har
 	}
 
 	for _, cmd := range commands {
-		logger.Logf("running command: %s %s", command, cmd)
+		logger.Logf("running command: %s %q", command, cmd.Command)
 
 		bg, err := RunCommand(context.TODO(), namespace, command, cmd, workdir, logger, logger)
 		if err != nil {

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -72,6 +72,7 @@ var APIServerDefaultArgs = []string{
 	"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
 	"--disable-admission-plugins=ServiceAccount,NamespaceLifecycle",
 	"--service-cluster-ip-range=10.0.0.0/24",
+	"--advertise-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}",
 }
 
 //TODO (kensipe): need to consider options around AlwaysAdmin https://github.com/kudobuilder/kudo/pull/1420/files#r391449597
@@ -886,9 +887,9 @@ type TestEnvironment struct {
 
 // StartTestEnvironment is a wrapper for controller-runtime's envtest that creates a Kubernetes API server and etcd
 // suitable for use in tests.
-func StartTestEnvironment() (env TestEnvironment, err error) {
+func StartTestEnvironment(KubeAPIServerFlags []string) (env TestEnvironment, err error) {
 	env.Environment = &envtest.Environment{
-		KubeAPIServerFlags: append(APIServerDefaultArgs, "--advertise-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}"),
+		KubeAPIServerFlags: KubeAPIServerFlags,
 	}
 
 	env.Config, err = env.Environment.Start()

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -24,7 +24,7 @@ var testenv TestEnvironment
 func TestMain(m *testing.M) {
 	var err error
 
-	testenv, err = StartTestEnvironment()
+	testenv, err = StartTestEnvironment(APIServerDefaultArgs)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/test/utils/mock_control_plane.go
+++ b/pkg/test/utils/mock_control_plane.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"bufio"
+	"os"
+)
+
+// ReadMockControllerConfig reads the mock control plane config file
+func ReadMockControllerConfig(filename string) (config []string, err error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		config = append(config, scanner.Text())
+	}
+	err = scanner.Err()
+	return
+}


### PR DESCRIPTION
This is based on the PR #77 from @zen-dog and extends the ability to configure the api server for advanced users.   There is an example configuration in the new `config` folder.

Example use is:

`go run cmd/kubectl-kuttl/main.go test pkg/test/test_data/ --control-plane-config=config/example-mock-controller.config `

An output for a run without configuration looks like:
```
go run cmd/kubectl-kuttl/main.go test pkg/test/test_data/ 
=== RUN   kuttl
    kuttl: harness.go:336: starting setup
    kuttl: harness.go:216: running tests with a mocked control plane (kube-apiserver and etcd).
    kuttl: harness.go:195: started test environment (kube-apiserver and etcd) in 4.506242639s, with following options:
        --advertise-address=127.0.0.1
        --etcd-servers={{ if .EtcdURL }}{{ .EtcdURL.String }}{{ end }}
        --cert-dir={{ .CertDir }}
        --insecure-port={{ if .URL }}{{ .URL.Port }}{{ end }}
        --insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}
        --secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}
        --disable-admission-plugins=ServiceAccount,NamespaceLifecycle
        --service-cluster-ip-range=10.0.0.0/24
        --advertise-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}
```

An output with configuration looks like:
```
go run cmd/kubectl-kuttl/main.go test pkg/test/test_data/ --control-plane-config=config/example-mock-controller.config 
=== RUN   kuttl
    kuttl: harness.go:336: starting setup
    kuttl: harness.go:216: running tests with a mocked control plane (kube-apiserver and etcd).
    kuttl: harness.go:195: started test environment (kube-apiserver and etcd) in 4.833250298s, with following options:
        --etcd-servers={{ if .EtcdURL }}{{ .EtcdURL.String }}{{ end }}
        --cert-dir={{ .CertDir }}
        --insecure-port={{ if .URL }}{{ .URL.Port }}{{ end }}
        --insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}
        --secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}
        --admission-control=AlwaysAdmit
        --service-cluster-ip-range=10.0.0.0/24
        --advertise-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}
```

Fixes #
