### PR TITLE
Add more logs for KIND initialization

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -114,12 +114,14 @@ func (h *Harness) RunKIND() (*rest.Config, error) {
 		h.kind = &kind
 
 		if h.kind.IsRunning() {
+			h.T.Logf("KIND is already running, using existing cluster")
 			return clientcmd.BuildConfigFromFlags("", h.explicitPath())
 		}
 
 		kindCfg := &kindConfig.Cluster{}
 
 		if h.TestSuite.KINDConfig != "" {
+			h.T.Logf("Loading KIND config from %s", h.TestSuite.KINDConfig)
 			var err error
 			kindCfg, err = loadKindConfig(h.TestSuite.KINDConfig)
 			if err != nil {
@@ -137,11 +139,12 @@ func (h *Harness) RunKIND() (*rest.Config, error) {
 
 		h.addNodeCaches(dockerClient, kindCfg)
 
+		h.T.Log("Starting KIND cluster")
 		if err := h.kind.Run(kindCfg); err != nil {
 			return nil, err
 		}
 
-		if err := h.kind.AddContainers(dockerClient, h.TestSuite.KINDContainers); err != nil {
+		if err := h.kind.AddContainers(dockerClient, h.TestSuite.KINDContainers, h.T); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/test/kind.go
+++ b/pkg/test/kind.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"testing"
 
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha3"
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -55,10 +56,12 @@ func (k *kind) IsRunning() bool {
 
 // AddContainers loads the named Docker containers into a KIND cluster.
 // The cluster must be running for this to work.
-func (k *kind) AddContainers(docker testutils.DockerClient, containers []string) error {
+func (k *kind) AddContainers(docker testutils.DockerClient, containers []string, t *testing.T) error {
 	if !k.IsRunning() {
 		panic("KIND cluster isn't running")
 	}
+
+	t.Logf("Adding Containers to KIND...\n")
 
 	nodes, err := k.Provider.ListNodes(k.context)
 	if err != nil {
@@ -67,6 +70,7 @@ func (k *kind) AddContainers(docker testutils.DockerClient, containers []string)
 
 	for _, node := range nodes {
 		for _, container := range containers {
+			t.Logf("Add image %s to node %s\n", container, node.String())
 			if err := loadContainer(docker, node, container); err != nil {
 				return err
 			}

--- a/pkg/test/kind_integration_test.go
+++ b/pkg/test/kind_integration_test.go
@@ -65,7 +65,7 @@ func TestAddContainers(t *testing.T) {
 		t.Errorf("failed to close image pull output: %v", err)
 	}
 
-	if err := kind.AddContainers(docker, []string{testImage}); err != nil {
+	if err := kind.AddContainers(docker, []string{testImage}, t); err != nil {
 		t.Errorf("failed to add container to KIND cluster: %v", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added some logs for the KIND cluster setup. Especially:
- Log info if an existing cluster is used (This might not be what you want, and at the moment you don't get notified about that)
- Log the loading of container images (This can take quite a while, and without logs it might not be clear while kuttl "doesn't do" anything)
- Log the KIND config that is used (It took me quite a while to figure out that I used the wrong config... )


