### PR TITLE
Add namespace to ENV variables when a command is executed

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -968,6 +968,7 @@ func RunCommand(ctx context.Context, namespace string, command string, cmd harne
 	builtCmd.Stdout = stdout
 	builtCmd.Stderr = stderr
 	builtCmd.Env = os.Environ()
+	builtCmd.Env = append(builtCmd.Env, fmt.Sprintf("NAMESPACE=%s", namespace))
 	builtCmd.Env = append(builtCmd.Env, fmt.Sprintf("KUBECONFIG=%s/kubeconfig", actualDir))
 	builtCmd.Env = append(builtCmd.Env, fmt.Sprintf("PATH=%s/bin/:%s", actualDir, os.Getenv("PATH")))
 

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -966,7 +966,7 @@ func RunCommand(ctx context.Context, namespace string, command string, cmd harne
 		return nil, err
 	}
 
-	kudoENV := make(map[string]string, 0)
+	kudoENV := make(map[string]string)
 	kudoENV["NAMESPACE"] = namespace
 	kudoENV["KUBECONFIG"] = fmt.Sprintf("%s/kubeconfig", actualDir)
 	kudoENV["PATH"] = fmt.Sprintf("%s/bin/:%s", actualDir, os.Getenv("PATH"))

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -915,16 +915,23 @@ func StartTestEnvironment() (env TestEnvironment, err error) {
 // GetArgs parses a command line string into its arguments and appends a namespace if it is not already set.
 // provides OS expansion of defined ENV VARs inside args to commands.  The expansion is limited to what is defined on the OS
 // and not variables defined for kuttl tests
-func GetArgs(ctx context.Context, command string, cmd harness.Command, namespace string) (*exec.Cmd, error) {
+func GetArgs(ctx context.Context, command string, cmd harness.Command, namespace string, env map[string]string) (*exec.Cmd, error) {
 	argSlice := []string{}
 
 	c := os.ExpandEnv(cmd.Command)
+	c = os.Expand(c, func(s string) string {
+		return env[s]
+	})
 	argSplit, err := shlex.Split(c)
 	if err != nil {
 		return nil, err
 	}
 
 	if command != "" && argSplit[0] != command {
+		command = os.Expand(command, func(s string) string {
+			return env[s]
+		})
+
 		argSlice = append(argSlice, os.ExpandEnv(command))
 	}
 
@@ -959,7 +966,12 @@ func RunCommand(ctx context.Context, namespace string, command string, cmd harne
 		return nil, err
 	}
 
-	builtCmd, err := GetArgs(ctx, command, cmd, namespace)
+	kudoENV := make(map[string]string, 0)
+	kudoENV["NAMESPACE"] = namespace
+	kudoENV["KUBECONFIG"] = fmt.Sprintf("%s/kubeconfig", actualDir)
+	kudoENV["PATH"] = fmt.Sprintf("%s/bin/:%s", actualDir, os.Getenv("PATH"))
+
+	builtCmd, err := GetArgs(ctx, command, cmd, namespace, kudoENV)
 	if err != nil {
 		return nil, err
 	}
@@ -968,9 +980,9 @@ func RunCommand(ctx context.Context, namespace string, command string, cmd harne
 	builtCmd.Stdout = stdout
 	builtCmd.Stderr = stderr
 	builtCmd.Env = os.Environ()
-	builtCmd.Env = append(builtCmd.Env, fmt.Sprintf("NAMESPACE=%s", namespace))
-	builtCmd.Env = append(builtCmd.Env, fmt.Sprintf("KUBECONFIG=%s/kubeconfig", actualDir))
-	builtCmd.Env = append(builtCmd.Env, fmt.Sprintf("PATH=%s/bin/:%s", actualDir, os.Getenv("PATH")))
+	for key, value := range kudoENV {
+		builtCmd.Env = append(builtCmd.Env, fmt.Sprintf("%s=%s", key, value))
+	}
 
 	// process started and exited with error
 	var exerr *exec.ExitError

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -433,7 +433,7 @@ func TestGetKubectlArgs(t *testing.T) {
 			cmd, err := GetArgs(context.TODO(), "kubectl", harness.Command{
 				Command:    test.args,
 				Namespaced: true,
-			}, test.namespace)
+			}, test.namespace, nil)
 			assert.Nil(t, err)
 			assert.Equal(t, test.expected, cmd.Args)
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
We might have to discuss this, but this just came up when using a script to modify the cluster in a test. 

I was able to use a workaround (set `namespaced: true` and then parse the added `--namespace <ns-name>` but it feels pretty clumsy, having the Namespace in the environment makes a lot of sense to me.

Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>