### PR TITLE
Decouple `skipDelete` from `skipClusterDelete` for cluster cleanup

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -420,7 +420,7 @@ func (h *Harness) Stop() {
 		}
 	}
 
-	if h.TestSuite.SkipClusterDelete || h.TestSuite.SkipDelete {
+	if h.TestSuite.SkipClusterDelete {
 		cwd, _ := os.Getwd()
 		kubeconfig := filepath.Join(cwd, "kubeconfig")
 


### PR DESCRIPTION
Summary:
It makes a lot of sense to decouple `skipDelete` (1) from the `skipClusterDelete` (2) option. With (1) enabled, `kuttl` will keep all cluster resources which will be gathered on cluster cleanup by e.g. kind log collector, which goes a long way with test debuggability. However, (2) can still be enabled and the cluster will be deleted.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>
