### PR TITLE
Flush logger after a command is done executing

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1007,6 +1007,9 @@ func RunCommands(logger Logger, namespace string, command string, commands []har
 		}
 		if bg != nil {
 			bgs = append(bgs, bg)
+		} else {
+			// We only need to flush if this is not a background command
+			logger.Flush()
 		}
 	}
 

--- a/pkg/test/utils/logger.go
+++ b/pkg/test/utils/logger.go
@@ -13,6 +13,7 @@ type Logger interface {
 	Logf(format string, args ...interface{})
 	WithPrefix(string) Logger
 	Write(p []byte) (n int, err error)
+	Flush()
 }
 
 // TestLogger implements the Logger interface to be compatible with the go test operator's
@@ -64,4 +65,11 @@ func (t *TestLogger) Write(p []byte) (n int, err error) {
 	}
 
 	return len(p), nil
+}
+
+func (t *TestLogger) Flush() {
+	if len(t.buffer) != 0 {
+		t.Log(string(t.buffer))
+		t.buffer = []byte{}
+	}
 }


### PR DESCRIPTION
Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>

**What this PR does / why we need it**:
Flush the log buffer after a command finished executing. For some reason the output was not ordered correctly, maybe because the logger is passed as stdout *and* stderr?

Fixes #84 
