### PR TITLE
Add more context information to returned error.

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -321,7 +321,7 @@ func Namespaced(dClient discovery.DiscoveryInterface, obj runtime.Object, namesp
 	resource, err := GetAPIResource(dClient, obj.GetObjectKind().GroupVersionKind())
 	if err != nil {
 
-		return "", "", err
+		return "", "", fmt.Errorf("retrieving API resource for %v failed: %v", obj.GetObjectKind().GroupVersionKind(), err)
 	}
 
 	if !resource.Namespaced {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

See https://github.com/kudobuilder/kuttl/issues/87#issuecomment-627171197

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #87

This is how the error looks like with this change:
```
    case.go:156: retrieving API resource for kudo.dev/v1alpha1, Kind=TestCase failed: the server could not find the requested resource
```

Signed-off-by: Marcin Owsiany <mowsiany@D2iQ.com>