### PR TITLE
Removed string command parameter

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -377,7 +377,7 @@ func (h *Harness) Setup() {
 			h.fatal(err)
 		}
 	}
-	bgs, errs := testutils.RunCommands(h.GetLogger(), "default", "", h.TestSuite.Commands, "")
+	bgs, errs := testutils.RunCommands(h.GetLogger(), "default", h.TestSuite.Commands, "")
 	// assign any background processes first for cleanup in case of any errors
 	h.bgProcesses = append(h.bgProcesses, bgs...)
 	if len(errs) > 0 {

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -379,7 +379,7 @@ func (s *Step) Run(namespace string) []error {
 				command.Background = false
 			}
 		}
-		if _, errors := testutils.RunCommands(s.Logger, namespace, "", s.Step.Commands, s.Dir); errors != nil {
+		if _, errors := testutils.RunCommands(s.Logger, namespace, s.Step.Commands, s.Dir); errors != nil {
 			testErrors = append(testErrors, errors...)
 		}
 	}

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -120,7 +120,7 @@ func TestRunCommand(t *testing.T) {
 	}
 
 	// assert foreground cmd returns nil
-	cmd, err := RunCommand(context.TODO(), "", "", hcmd, "", stdout, stderr)
+	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr)
 	assert.NoError(t, err)
 	assert.Nil(t, cmd)
 	// foreground processes should have stdout
@@ -130,7 +130,7 @@ func TestRunCommand(t *testing.T) {
 	stdout = &bytes.Buffer{}
 
 	// assert background cmd returns process
-	cmd, err = RunCommand(context.TODO(), "", "", hcmd, "", stdout, stderr)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr)
 	assert.NoError(t, err)
 	assert.NotNil(t, cmd)
 	// no stdout for background processes
@@ -146,12 +146,12 @@ func TestRunCommandIgnoreErrors(t *testing.T) {
 	}
 
 	// assert foreground cmd returns nil
-	cmd, err := RunCommand(context.TODO(), "", "", hcmd, "", stdout, stderr)
+	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr)
 	assert.NoError(t, err)
 	assert.Nil(t, cmd)
 
 	hcmd.IgnoreFailure = false
-	cmd, err = RunCommand(context.TODO(), "", "", hcmd, "", stdout, stderr)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr)
 	assert.Error(t, err)
 	assert.Nil(t, cmd)
 
@@ -160,7 +160,7 @@ func TestRunCommandIgnoreErrors(t *testing.T) {
 		Command:       "bad-command",
 		IgnoreFailure: true,
 	}
-	cmd, err = RunCommand(context.TODO(), "", "", hcmd, "", stdout, stderr)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr)
 	assert.Error(t, err)
 	assert.Nil(t, cmd)
 }

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -257,7 +257,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "namespace long, combined already set at end is not modified",
 			namespace: "default",
-			args:      "kuttl test --namespace=test-canary",
+			args:      "kubectl kuttl test --namespace=test-canary",
 			expected: []string{
 				"kubectl", "kuttl", "test", "--namespace=test-canary",
 			},
@@ -265,7 +265,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "namespace long already set at end is not modified",
 			namespace: "default",
-			args:      "kuttl test --namespace test-canary",
+			args:      "kubectl kuttl test --namespace test-canary",
 			expected: []string{
 				"kubectl", "kuttl", "test", "--namespace", "test-canary",
 			},
@@ -273,7 +273,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "namespace short, combined already set at end is not modified",
 			namespace: "default",
-			args:      "kuttl test -n=test-canary",
+			args:      "kubectl kuttl test -n=test-canary",
 			expected: []string{
 				"kubectl", "kuttl", "test", "-n=test-canary",
 			},
@@ -281,47 +281,15 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "namespace short already set at end is not modified",
 			namespace: "default",
-			args:      "kuttl test -n test-canary",
+			args:      "kubectl kuttl test -n test-canary",
 			expected: []string{
 				"kubectl", "kuttl", "test", "-n", "test-canary",
 			},
 		},
 		{
-			testName:  "namespace long, combined already set at beginning is not modified",
-			namespace: "default",
-			args:      "--namespace=test-canary kuttl test",
-			expected: []string{
-				"kubectl", "--namespace=test-canary", "kuttl", "test",
-			},
-		},
-		{
-			testName:  "namespace long already set at beginning is not modified",
-			namespace: "default",
-			args:      "--namespace test-canary kuttl test",
-			expected: []string{
-				"kubectl", "--namespace", "test-canary", "kuttl", "test",
-			},
-		},
-		{
-			testName:  "namespace short, combined already set at beginning is not modified",
-			namespace: "default",
-			args:      "-n=test-canary kuttl test",
-			expected: []string{
-				"kubectl", "-n=test-canary", "kuttl", "test",
-			},
-		},
-		{
-			testName:  "namespace short already set at beginning is not modified",
-			namespace: "default",
-			args:      "-n test-canary kuttl test",
-			expected: []string{
-				"kubectl", "-n", "test-canary", "kuttl", "test",
-			},
-		},
-		{
 			testName:  "namespace long, combined already set in middle is not modified",
 			namespace: "default",
-			args:      "kuttl --namespace=test-canary test",
+			args:      "kubectl kuttl --namespace=test-canary test",
 			expected: []string{
 				"kubectl", "kuttl", "--namespace=test-canary", "test",
 			},
@@ -329,7 +297,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "namespace long already set in middle is not modified",
 			namespace: "default",
-			args:      "kuttl --namespace test-canary test",
+			args:      "kubectl kuttl --namespace test-canary test",
 			expected: []string{
 				"kubectl", "kuttl", "--namespace", "test-canary", "test",
 			},
@@ -337,7 +305,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "namespace short, combined already set in middle is not modified",
 			namespace: "default",
-			args:      "kuttl -n=test-canary test",
+			args:      "kubectl kuttl -n=test-canary test",
 			expected: []string{
 				"kubectl", "kuttl", "-n=test-canary", "test",
 			},
@@ -345,7 +313,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "namespace short already set in middle is not modified",
 			namespace: "default",
-			args:      "kuttl -n test-canary test",
+			args:      "kubectl kuttl -n test-canary test",
 			expected: []string{
 				"kubectl", "kuttl", "-n", "test-canary", "test",
 			},
@@ -353,7 +321,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "namespace not set is appended",
 			namespace: "default",
-			args:      "kuttl test",
+			args:      "kubectl kuttl test",
 			expected: []string{
 				"kubectl", "kuttl", "test", "--namespace", "default",
 			},
@@ -361,7 +329,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "unknown arguments do not break parsing with namespace is not set",
 			namespace: "default",
-			args:      "kuttl test --config kuttl-test.yaml",
+			args:      "kubectl kuttl test --config kuttl-test.yaml",
 			expected: []string{
 				"kubectl", "kuttl", "test", "--config", "kuttl-test.yaml", "--namespace", "default",
 			},
@@ -369,7 +337,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "unknown arguments do not break parsing if namespace is set at beginning",
 			namespace: "default",
-			args:      "--namespace=test-canary kuttl test --config kuttl-test.yaml",
+			args:      "kubectl --namespace=test-canary kuttl test --config kuttl-test.yaml",
 			expected: []string{
 				"kubectl", "--namespace=test-canary", "kuttl", "test", "--config", "kuttl-test.yaml",
 			},
@@ -377,7 +345,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "unknown arguments do not break parsing if namespace is set at middle",
 			namespace: "default",
-			args:      "kuttl --namespace=test-canary test --config kuttl-test.yaml",
+			args:      "kubectl kuttl --namespace=test-canary test --config kuttl-test.yaml",
 			expected: []string{
 				"kubectl", "kuttl", "--namespace=test-canary", "test", "--config", "kuttl-test.yaml",
 			},
@@ -385,7 +353,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "unknown arguments do not break parsing if namespace is set at end",
 			namespace: "default",
-			args:      "kuttl test --config kuttl-test.yaml --namespace=test-canary",
+			args:      "kubectl kuttl test --config kuttl-test.yaml --namespace=test-canary",
 			expected: []string{
 				"kubectl", "kuttl", "test", "--config", "kuttl-test.yaml", "--namespace=test-canary",
 			},
@@ -393,7 +361,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "quotes are respected when parsing",
 			namespace: "default",
-			args:      "kuttl \"test quoted\"",
+			args:      "kubectl kuttl \"test quoted\"",
 			expected: []string{
 				"kubectl", "kuttl", "test quoted", "--namespace", "default",
 			},
@@ -401,7 +369,7 @@ func TestGetKubectlArgs(t *testing.T) {
 		{
 			testName:  "os ENV are expanded",
 			namespace: "default",
-			args:      "kuttl $TEST_FOO ${TEST_FOO}",
+			args:      "kubectl kuttl $TEST_FOO ${TEST_FOO}",
 			env:       map[string]string{"TEST_FOO": "test"},
 			expected: []string{
 				"kubectl", "kuttl", "test", "test", "--namespace", "default",
@@ -430,7 +398,7 @@ func TestGetKubectlArgs(t *testing.T) {
 					}
 				}()
 			}
-			cmd, err := GetArgs(context.TODO(), "kubectl", harness.Command{
+			cmd, err := GetArgs(context.TODO(), harness.Command{
 				Command:    test.args,
 				Namespaced: true,
 			}, test.namespace, nil)


### PR DESCRIPTION
It's not used anywhere except for a unit test, probably left over from early prototyping

Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>