### PR TITLE
Dockerized KUTTL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# kuttl builder
+FROM golang:1.14 as builder
+
+WORKDIR /go/src/kuttl
+COPY . .
+
+RUN go get -d -v ./...
+RUN make cli
+
+# release image with kubectl + kuttl
+FROM golang:1.14
+
+RUN apt-get update && apt-get install -y curl wget gnupg2 apt-transport-https vim
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+
+RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
+RUN apt-get update
+RUN  apt-get install -y kubectl
+
+COPY --from=builder /go/src/kuttl/bin/kubectl-kuttl /usr/bin/kubectl-kuttl
+
+WORKDIR /opt/project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,20 @@
+
+#
+# used to run kuttl tests from docker
+# it is expected that a mount pt is provided where /opt/project is the root of the testsuite
+# the root of the mount point needs a `kuttl-test.yaml` and a proper `kubeconfig` file which
+# a process running in docker can reach.  If using kind, then `kind get kubeconfig --internal > kubeconfig`
+# will provide the proper configuration for 0.7.0.  0.8.0 breaks this ability and is being worked on in the
+# kind community.
+# Assuming a test folders at mount root named "e2e" then:
+# docker run -v $PWD:/opt/project kuttl e2e
+# will run tests against the e2e folders.
+#
+# IF you want run tests from within a cluster, then specify `-e KUBECONFIG=`.  An empty KUBECONFIG will
+# result in kuttl using the in-cluster-config.
+# ex. docker run -e KUBECONFIG= -v $PWD:/opt/project kuttl e2e
+# artifacts by default will land in the root of the mount point.
+
 # kuttl builder
 FROM golang:1.14 as builder
 
@@ -21,4 +38,8 @@ COPY --from=builder /go/src/kuttl/bin/kubectl-kuttl /usr/bin/kubectl-kuttl
 
 WORKDIR /opt/project
 
+# default configuration
 ENV KUBECONFIG=kubeconfig
+
+# standard kuttl test in entry point, flags and test folder can be provided as CMD
+ENTRYPOINT ["kubectl", "kuttl", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN go get -d -v ./...
 RUN make cli
 
 # release image with kubectl + kuttl
-FROM golang:1.14
+FROM debian:buster
 
 RUN apt-get update && apt-get install -y curl wget gnupg2 apt-transport-https vim
 RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,5 @@ RUN  apt-get install -y kubectl
 COPY --from=builder /go/src/kuttl/bin/kubectl-kuttl /usr/bin/kubectl-kuttl
 
 WORKDIR /opt/project
+
+ENV KUBECONFIG=kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,11 @@ cli:
 cli-clean:
 	rm -f bin/${CLI}
 
+.PHONY: docker
+# build docker image
+docker:
+	docker build . -t kuttl
+
 # Install CLI
 cli-install:
 	go install -ldflags "${LDFLAGS}" ./cmd/kubectl-kuttl

--- a/config/basic-kuttl-test.yaml
+++ b/config/basic-kuttl-test.yaml
@@ -2,4 +2,3 @@ apiVersion: kudo.dev/v1beta1
 kind: TestSuite
 parallel: 4
 timeout: 120
-startControlPlane: true

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,6 +1,4 @@
 apiVersion: kudo.dev/v1beta1
 kind: TestSuite
-testDirs:
-- ./test/integration
-startControlPlane: true
 parallel: 4
+timeout: 120


### PR DESCRIPTION
Currently for testing and feedback... It is likely we want to release this with goreleaser which needs to be connected in.

This creates a dockerized kuttl image and introduces a new `make docker` task for the makefile.

The documentation is in the Dockerfile... here are some additional details / highlights.

1. The docker image needs to be mounted to a folder it can read
2. At the root, should be a kubeconfig and kuttl-test.yaml
3. there is an entry-point which uses `kubectl kuttl test` and commands can be added to it
4. it is possible to run tests from in a cluster... if this is the case, then set the ENV `KUBECONFIG=` to nothing.  This will be picked up and will use the in-cluster-config for connection (part of controller-runtime)
5. if using from kuttl project you will need to override the default kuttl-test.yaml, it is for our integration tests and starts the control-plane
6. kuttl docker image is designed ONLY for use with clusters no control-plane or kind support (mean it will not start-up kind, it can run against kind if started externally)
7. there are issues with kind 0.8.0 which are being worked on in that community.

To use, example:
From the kuttl project, if you 
`mkdir -p e2e/pod`
and provide:
00-install.yaml
```
apiVersion: v1
kind: Pod
metadata:
  name: static-web
spec:
  containers:
    - name: web
      image: nginx
```
and 00-assert.yaml
```
apiVersion: v1
kind: Pod
metadata:
  name: static-web
status:
  phase: Running
```
after `make docker`
1. start kind (v0.7.0)
2. run: `kind get kubeconfig --internal > kubeconfig`
3. run: `docker run -v $PWD:/opt/project kuttl e2e --config config/basic-kuttl-test.yaml`

```
$ docker run -v $PWD:/opt/project kuttl e2e --config config/basic-kuttl-test.yaml 
=== RUN   kuttl
    kuttl: harness.go:339: starting setup
    kuttl: harness.go:225: running tests using configured kubeconfig.
    kuttl: harness.go:297: running tests
    kuttl: harness.go:67: going to run test suite with timeout of 120 seconds for each step
=== RUN   kuttl/harness
=== RUN   kuttl/harness/pod
=== PAUSE kuttl/harness/pod
=== CONT  kuttl/harness/pod
    kuttl/harness/pod: logger.go:41: 20:55:30 | pod | Creating namespace: kudo-test-classic-mullet
    kuttl/harness/pod: logger.go:41: 20:55:30 | pod/0-install | starting test step 0-install
    kuttl/harness/pod: logger.go:41: 20:55:31 | pod/0-install | Pod:kudo-test-classic-mullet/static-web created
    kuttl/harness/pod: logger.go:41: 20:55:33 | pod/0-install | test step completed 0-install
    kuttl/harness/pod: logger.go:41: 20:55:33 | pod | pod events from ns kudo-test-classic-mullet:
    kuttl/harness/pod: logger.go:41: 20:55:33 | pod | 2020-05-13 20:55:31 +0000 UTC	Normal	Scheduled	Successfully assigned kudo-test-classic-mullet/static-web to kind-control-plane
    kuttl/harness/pod: logger.go:41: 20:55:33 | pod | 2020-05-13 20:55:31 +0000 UTC	Normal	Pulling	Pulling image "nginx"
    kuttl/harness/pod: logger.go:41: 20:55:33 | pod | 2020-05-13 20:55:32 +0000 UTC	Normal	Pulled	Successfully pulled image "nginx"
    kuttl/harness/pod: logger.go:41: 20:55:33 | pod | 2020-05-13 20:55:32 +0000 UTC	Normal	Created	Created container web
    kuttl/harness/pod: logger.go:41: 20:55:33 | pod | 2020-05-13 20:55:32 +0000 UTC	Normal	Started	Started container web
    kuttl/harness/pod: logger.go:41: 20:55:33 | pod | Deleting namespace: kudo-test-classic-mullet
    kuttl: harness.go:326: run tests finished
--- PASS: kuttl (2.85s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/pod (2.33s)
PASS
```
Of course you can run from any directory or against any cluster.