### PR TITLE
Make it possible to increase KIND log verbosity.

### DIFF
--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -193,6 +193,10 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 	// The default value here is only used for the help message. The default is actually enforced in RunTests.
 	testCmd.Flags().IntVar(&parallel, "parallel", 8, "The maximum number of tests to run at once.")
 
+	// This cannot be a global flag because pkg/test/utils.RunTests calls flag.Parse which barfs on unknown top-level flags.
+	// Putting it here at least does not advertise it on a level where using it is impossible.
+	test.SetFlags(testCmd.Flags())
+
 	return testCmd
 }
 

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -111,7 +111,7 @@ func (h *Harness) RunKIND() (*rest.Config, error) {
 			return nil, err
 		}
 
-		kind := newKind(h.TestSuite.KINDContext, h.explicitPath())
+		kind := newKind(h.TestSuite.KINDContext, h.explicitPath(), h.GetLogger())
 		h.kind = &kind
 
 		if h.kind.IsRunning() {

--- a/pkg/test/kind.go
+++ b/pkg/test/kind.go
@@ -35,6 +35,7 @@ func (k *kind) Run(config *v1alpha3.Cluster) error {
 		k.context,
 		cluster.CreateWithV1Alpha3Config(config),
 		cluster.CreateWithKubeconfigPath(k.explicitPath),
+		cluster.CreateWithRetain(true),
 	)
 }
 

--- a/pkg/test/kind.go
+++ b/pkg/test/kind.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
+	"sigs.k8s.io/kind/pkg/log"
 
 	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
 )
@@ -19,8 +20,45 @@ type kind struct {
 	explicitPath string
 }
 
-func newKind(kindContext string, explicitPath string) kind {
-	provider := cluster.NewProvider()
+type kindLogger struct {
+	l testutils.Logger
+}
+
+func (k kindLogger) Info(message string) {
+	k.l.Log(message)
+}
+
+func (k kindLogger) Infof(format string, args ...interface{}) {
+	k.l.Logf(format, args...)
+}
+
+func (k kindLogger) Enabled() bool {
+	return true
+}
+
+func (k kindLogger) Warn(message string) {
+	k.l.Log(message)
+}
+
+func (k kindLogger) Warnf(format string, args ...interface{}) {
+	k.l.Logf(format, args...)
+}
+
+func (k kindLogger) Error(message string) {
+	k.l.Log(message)
+}
+
+func (k kindLogger) Errorf(format string, args ...interface{}) {
+	k.l.Logf(format, args...)
+}
+
+func (k kindLogger) V(level log.Level) log.InfoLogger {
+	return k
+}
+
+func newKind(kindContext string, explicitPath string, logger testutils.Logger) kind {
+
+	provider := cluster.NewProvider(cluster.ProviderWithLogger(&kindLogger{logger}))
 
 	return kind{
 		Provider:     provider,

--- a/pkg/test/kind.go
+++ b/pkg/test/kind.go
@@ -8,7 +8,6 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
-	"sigs.k8s.io/kind/pkg/log"
 
 	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
 )
@@ -18,42 +17,6 @@ type kind struct {
 	Provider     *cluster.Provider
 	context      string
 	explicitPath string
-}
-
-type kindLogger struct {
-	l testutils.Logger
-}
-
-func (k kindLogger) Info(message string) {
-	k.l.Log(message)
-}
-
-func (k kindLogger) Infof(format string, args ...interface{}) {
-	k.l.Logf(format, args...)
-}
-
-func (k kindLogger) Enabled() bool {
-	return true
-}
-
-func (k kindLogger) Warn(message string) {
-	k.l.Log(message)
-}
-
-func (k kindLogger) Warnf(format string, args ...interface{}) {
-	k.l.Logf(format, args...)
-}
-
-func (k kindLogger) Error(message string) {
-	k.l.Log(message)
-}
-
-func (k kindLogger) Errorf(format string, args ...interface{}) {
-	k.l.Logf(format, args...)
-}
-
-func (k kindLogger) V(level log.Level) log.InfoLogger {
-	return k
 }
 
 func newKind(kindContext string, explicitPath string, logger testutils.Logger) kind {

--- a/pkg/test/kind_integration_test.go
+++ b/pkg/test/kind_integration_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/thoas/go-funk"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha3"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
+
+	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
 )
 
 const (
@@ -26,7 +28,7 @@ const (
 func TestAddContainers(t *testing.T) {
 	ctx := context.Background()
 
-	kind := newKind(kindTestContext, "kubeconfig")
+	kind := newKind(kindTestContext, "kubeconfig", testutils.NewTestLogger(t, ""))
 
 	config := v1alpha3.Cluster{}
 

--- a/pkg/test/kind_logger.go
+++ b/pkg/test/kind_logger.go
@@ -1,0 +1,91 @@
+package test
+
+import (
+	"strconv"
+
+	"github.com/spf13/pflag"
+	"sigs.k8s.io/kind/pkg/log"
+
+	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
+)
+
+type level int32
+
+var verbosity level
+
+func SetFlags(flags *pflag.FlagSet) {
+	flags.VarP(&verbosity, "v", "v", "Logging verbosity level. 0=normal, 1=verbose, 2=detailed, 3+=trace.")
+}
+
+func (l *level) Get() interface{} {
+	return *l
+}
+
+func (l *level) String() string {
+	return strconv.FormatInt(int64(*l), 10)
+}
+
+func (l *level) Set(value string) error {
+	v, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	*l = level(v)
+	return nil
+}
+
+func (l *level) Type() string {
+	return string(*l)
+}
+
+// kindLogger lets KIND log to the kuttl logger.
+// KIND log level N corresponds to kuttl log level N+1, such that
+// using the default 0 kuttl log level produces no KIND output.
+type kindLogger struct {
+	l testutils.Logger
+}
+
+func (k kindLogger) V(level log.Level) log.InfoLogger {
+	if int(level) >= int(verbosity) {
+		return &nopLogger{}
+	}
+	return k
+}
+
+func (k kindLogger) Warn(message string) {
+	k.l.Log(message)
+}
+
+func (k kindLogger) Warnf(format string, args ...interface{}) {
+	k.l.Logf(format, args...)
+}
+
+func (k kindLogger) Error(message string) {
+	k.l.Log(message)
+}
+
+func (k kindLogger) Errorf(format string, args ...interface{}) {
+	k.l.Logf(format, args...)
+}
+
+func (k kindLogger) Info(message string) {
+	k.l.Log(message)
+}
+
+func (k kindLogger) Infof(format string, args ...interface{}) {
+	k.l.Logf(format, args...)
+}
+
+func (k kindLogger) Enabled() bool {
+	return true
+}
+
+type nopLogger struct{}
+
+func (n *nopLogger) Enabled() bool {
+	return false
+}
+
+func (n *nopLogger) Info(message string) {}
+
+func (n *nopLogger) Infof(format string, args ...interface{}) {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

- retain KIND nodes on cluster creation failures, so there is something to collect logs from,
- introduce a notion of verbosity in `kuttl` and plumb it through to KIND logging

This makes it possible to debug KIND cluster failures such as the one described in https://github.com/mesosphere/kudo-cassandra-operator/pull/110#issue-418424225