### PR TITLE
Restoring Cleaner Logging of Run Commands

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1004,7 +1004,7 @@ func RunCommands(logger Logger, namespace string, commands []harness.Command, wo
 	}
 
 	for _, cmd := range commands {
-		logger.Logf("running command: %s", cmd)
+		logger.Logf("running command: %q", cmd.Command)
 
 		bg, err := RunCommand(context.TODO(), namespace, cmd, workdir, logger, logger)
 		if err != nil {


### PR DESCRIPTION
This was lost in the command refactor of #90 
Restoring it!

Signed-off-by: Ken Sipe <kensipe@gmail.com>
