### PR TITLE
Do not expand a double dollar sign symbol in command strings.

### DIFF
--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -407,3 +407,10 @@ func TestGetKubectlArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestExpandEnv(t *testing.T) {
+	os.Setenv("KUTTL_TEST_123", "hello")
+	assert.Equal(t, "hello $  world", ExpandEnv("$KUTTL_TEST_123 $$ $DOES_NOT_EXIST_1234 ${EXPAND_ME}", map[string]string{
+		"EXPAND_ME": "world",
+	}))
+}


### PR DESCRIPTION
Signed-off-by: jbarrick@mesosphere.com <jbarrick@mesosphere.com>

**What this PR does / why we need it**:

This makes it so that our environment expansion in the `command` string has escapable dollar signs. Previously, it was impossible to include a `$` in your command string.