### PR TITLE
Corrupt TestSuite File should NOT Panic

### DIFF
--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	harness "github.com/kudobuilder/kuttl/pkg/apis/testharness/v1beta1"
 	"github.com/kudobuilder/kuttl/pkg/test"
@@ -87,7 +88,13 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 					kind := obj.GetObjectKind().GroupVersionKind().Kind
 
 					if kind == "TestSuite" {
-						options = *obj.(*harness.TestSuite)
+						switch ts := obj.(type) {
+						case *harness.TestSuite:
+							options = *ts
+						case *unstructured.Unstructured:
+							log.Println(fmt.Errorf("bad configuration in file %q", configPath))
+						}
+
 					} else {
 						log.Println(fmt.Errorf("unknown object type: %s", kind))
 					}


### PR DESCRIPTION
A corrupt testsuite config file (for example starting with `apiVersion: kuttl.dev/v1beta1` instead of ` apiVersion: kudo.dev/v1beta1`  will cause kuttl to panic.. this PR fixes that.

Fixes: #42 

Signed-off-by: Ken Sipe <kensipe@gmail.com>
