### PR TITLE
KEP04: TestStep.Apply Feature

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -63,6 +63,11 @@ type TestStep struct {
 
 	// +kubebuilder:validation:Format:=int64
 	Index int `json:"index,omitempty"`
+
+	// files or directories to apply at the beginning of the test step. Useful to reuse a number of applies across tests / test steps.
+	// all relative paths are relative to the CWD of kuttl.  This has the same behavior as indexed manifest file.
+	Apply []string `json:"apply,omitempty"`
+
 	// Objects to delete at the beginning of the test step.
 	Delete []ObjectReference `json:"delete,omitempty"`
 

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -64,8 +64,8 @@ type TestStep struct {
 	// +kubebuilder:validation:Format:=int64
 	Index int `json:"index,omitempty"`
 
-	// files or directories to apply at the beginning of the test step. Useful to reuse a number of applies across tests / test steps.
-	// all relative paths are relative to the CWD of kuttl.  This has the same behavior as indexed manifest file.
+	// files or directories to apply in the test step. Useful to reuse a number of applies across tests / test steps.
+	// all relative paths are relative to the folder the TestStep is defined in. 
 	Apply []string `json:"apply,omitempty"`
 
 	// Objects to delete at the beginning of the test step.

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -54,7 +54,7 @@ type TestSuite struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// TestStep settings to apply to a test step.
+// TestStep settings to apply to a test step.go
 type TestStep struct {
 	// The type meta object, should always be a GVK of kudo.dev/v1beta1/TestStep.
 	metav1.TypeMeta `json:",inline"`
@@ -65,7 +65,7 @@ type TestStep struct {
 	Index int `json:"index,omitempty"`
 
 	// files or directories to apply in the test step. Useful to reuse a number of applies across tests / test steps.
-	// all relative paths are relative to the folder the TestStep is defined in. 
+	// all relative paths are relative to the folder the TestStep is defined in.
 	Apply []string `json:"apply,omitempty"`
 
 	// Objects to delete at the beginning of the test step.

--- a/pkg/file/files.go
+++ b/pkg/file/files.go
@@ -1,0 +1,52 @@
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
+)
+
+// from a list of paths, returns an array of runtime objects
+func ToRuntimeObjects(paths []string) ([]runtime.Object, error) {
+	apply := []runtime.Object{}
+
+	for _, path := range paths {
+		objs, err := testutils.LoadYAML(path)
+		if err != nil {
+			return nil, fmt.Errorf("file %q load yaml error", path)
+		}
+		apply = append(apply, objs...)
+	}
+
+	return apply, nil
+}
+
+// From a file or dir path returns an array of flat file paths
+func FromPath(path string) ([]string, error) {
+	files := []string{}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("file mode issue with %w", err)
+	}
+	if fi.IsDir() {
+		fileInfos, err := ioutil.ReadDir(path)
+		if err != nil {
+			return nil, err
+		}
+		for _, fileInfo := range fileInfos {
+			if !fileInfo.IsDir() {
+				files = append(files, filepath.Join(path, fileInfo.Name()))
+			}
+		}
+	} else {
+		files = append(files, path)
+	}
+
+	return files, nil
+}

--- a/pkg/file/files.go
+++ b/pkg/file/files.go
@@ -27,8 +27,13 @@ func ToRuntimeObjects(paths []string) ([]runtime.Object, error) {
 }
 
 // From a file or dir path returns an array of flat file paths
-func FromPath(path string) ([]string, error) {
+// pattern is a filepath.Match pattern to limit files to a pattern
+func FromPath(path, pattern string) ([]string, error) {
 	files := []string{}
+
+	if pattern == "" {
+		pattern = "*"
+	}
 
 	fi, err := os.Stat(path)
 	if err != nil {
@@ -40,7 +45,11 @@ func FromPath(path string) ([]string, error) {
 			return nil, err
 		}
 		for _, fileInfo := range fileInfos {
-			if !fileInfo.IsDir() {
+			match, err := filepath.Match(pattern, fileInfo.Name())
+			if err != nil {
+				return nil, err
+			}
+			if !fileInfo.IsDir() && match {
 				files = append(files, filepath.Join(path, fileInfo.Name()))
 			}
 		}

--- a/pkg/file/files_test.go
+++ b/pkg/file/files_test.go
@@ -8,13 +8,45 @@ import (
 
 func TestFromPath(t *testing.T) {
 
-	paths, err := FromPath("testdata/path")
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(paths))
-	assert.Equal(t, "testdata/path/test1.yaml", paths[0])
+	tests := []struct {
+		name     string
+		path     string
+		pattern  string
+		expected []string
+		wantErr  bool
+	}{
+		{
+			name:     `good path no extension`,
+			path:     "testdata/path",
+			pattern:  "",
+			expected: []string{"testdata/path/skip.txt", "testdata/path/test1.yaml", "testdata/path/test2.yaml"},
+			wantErr:  false,
+		},
+		{
+			name:     `good path yaml extension`,
+			path:     "testdata/path",
+			pattern:  "*.yaml",
+			expected: []string{"testdata/path/test1.yaml", "testdata/path/test2.yaml"},
+			wantErr:  false,
+		},
+		{
+			name:     `bad path`,
+			path:     "testdata/badpath",
+			pattern:  "",
+			expected: []string{},
+			wantErr:  true,
+		},
+	}
 
-	_, err = FromPath("testdata/badpath")
-	assert.Error(t, err, "file mode issue with stat testdata/badpath: no such file or directory")
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+
+			paths, err := FromPath(tt.path, tt.pattern)
+			assert.Equal(t, tt.wantErr, err != nil, "expected error %v, but got %v", tt.wantErr, err)
+			assert.ElementsMatch(t, paths, tt.expected)
+		})
+	}
 }
 
 func TestToRuntimeObjects(t *testing.T) {

--- a/pkg/file/files_test.go
+++ b/pkg/file/files_test.go
@@ -1,0 +1,30 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromPath(t *testing.T) {
+
+	paths, err := FromPath("testdata/path")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(paths))
+	assert.Equal(t, "testdata/path/test1.yaml", paths[0])
+
+	_, err = FromPath("testdata/badpath")
+	assert.Error(t, err, "file mode issue with stat testdata/badpath: no such file or directory")
+}
+
+func TestToRuntimeObjects(t *testing.T) {
+	files := []string{"testdata/path/test1.yaml"}
+	objs, err := ToRuntimeObjects(files)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(objs))
+	assert.Equal(t, "Pod", objs[0].GetObjectKind().GroupVersionKind().Kind)
+
+	files = append(files, "testdata/path/test2.yaml")
+	_, err = ToRuntimeObjects(files)
+	assert.Error(t, err, "file \"testdata/path/test2.yaml\" load yaml error")
+}

--- a/pkg/file/testdata/path/missing/readme.txt
+++ b/pkg/file/testdata/path/missing/readme.txt
@@ -1,0 +1,1 @@
+this file and directory are NOT read by the `FromPath` function on `testdata/path`

--- a/pkg/file/testdata/path/skip.txt
+++ b/pkg/file/testdata/path/skip.txt
@@ -1,0 +1,1 @@
+with the proper pattern this file is skipped

--- a/pkg/file/testdata/path/test1.yaml
+++ b/pkg/file/testdata/path/test1.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello2
+spec:
+  containers:
+    - image: alpine
+      name: test

--- a/pkg/file/testdata/path/test2.yaml
+++ b/pkg/file/testdata/path/test2.yaml
@@ -1,0 +1,1 @@
+corrupt file

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -477,7 +477,7 @@ func (s *Step) LoadYAML(file string) error {
 	// process provided steps configured TestStep kind
 	if s.Step != nil {
 		for _, applyPath := range s.Step.Apply {
-			paths, err := kfile.FromPath(filepath.Join(s.Dir, applyPath))
+			paths, err := kfile.FromPath(filepath.Join(s.Dir, applyPath), "*.yaml")
 			if err != nil {
 				return fmt.Errorf("step %q %w", s.Name, err)
 			}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	harness "github.com/kudobuilder/kuttl/pkg/apis/testharness/v1beta1"
+	kfile "github.com/kudobuilder/kuttl/pkg/file"
 	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
 )
 
@@ -470,6 +471,21 @@ func (s *Step) LoadYAML(file string) error {
 			}
 		} else {
 			apply = append(apply, obj)
+		}
+	}
+
+	// process provided steps configured TestStep kind
+	if s.Step != nil {
+		for _, applyPath := range s.Step.Apply {
+			paths, err := kfile.FromPath(filepath.Join(s.Dir, applyPath))
+			if err != nil {
+				return fmt.Errorf("step %q %w", s.Name, err)
+			}
+			applies, err := kfile.ToRuntimeObjects(paths)
+			if err != nil {
+				return fmt.Errorf("step %q %w", s.Name, err)
+			}
+			apply = append(apply, applies...)
 		}
 	}
 

--- a/pkg/test/test_data/teststep-apply/00-assert.yaml
+++ b/pkg/test/test_data/teststep-apply/00-assert.yaml
@@ -1,0 +1,14 @@
+# Verify that the pods were created.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+status:
+  phase: Pending
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello2
+status:
+  phase: Pending

--- a/pkg/test/test_data/teststep-apply/00-create.yaml
+++ b/pkg/test/test_data/teststep-apply/00-create.yaml
@@ -1,0 +1,6 @@
+# using apply from TestStep from multiple folder locations
+apiVersion: kudo.dev/v1beta1
+kind: TestStep
+apply:
+  - hello.yaml
+  - hello2/hello2.yaml

--- a/pkg/test/test_data/teststep-apply/hello.yaml
+++ b/pkg/test/test_data/teststep-apply/hello.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+spec:
+  containers:
+    - image: alpine
+      name: test

--- a/pkg/test/test_data/teststep-apply/hello2/hello2.yaml
+++ b/pkg/test/test_data/teststep-apply/hello2/hello2.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello2
+spec:
+  containers:
+    - image: alpine
+      name: test


### PR DESCRIPTION
TestStep has an `apply` property added which is a list of files.
As stated in KEP04, this will allow the reuse of files in multiple test steps.  In addition we have already seen a lot of `command: kubectl apply -f xyz.yaml` to enable this same behavior.   This provides a more concise way of expressing this common need.

Example:  `00-create.yaml`

```
apiVersion: kudo.dev/v1beta1
kind: TestStep
apply:
  - hello.yaml
  - hello2/hello2.yaml
  - ../hello3.yaml
  - directory
```
All the options above have been tested.  The relative path is relative to the step folder the TestStep is in.

