### PR TITLE
Command Timeouts

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -371,7 +371,7 @@ func (h *Harness) Setup() {
 			h.fatal(fmt.Errorf("fatal error installing manifests: %v", err))
 		}
 	}
-	bgs, errs := testutils.RunCommands(h.GetLogger(), "default", h.TestSuite.Commands, "")
+	bgs, errs := testutils.RunCommands(h.GetLogger(), "default", h.TestSuite.Commands, "", h.TestSuite.Timeout)
 	// assign any background processes first for cleanup in case of any errors
 	h.bgProcesses = append(h.bgProcesses, bgs...)
 	if len(errs) > 0 {

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -380,7 +380,7 @@ func (s *Step) Run(namespace string) []error {
 				command.Background = false
 			}
 		}
-		if _, errors := testutils.RunCommands(s.Logger, namespace, s.Step.Commands, s.Dir); errors != nil {
+		if _, errors := testutils.RunCommands(s.Logger, namespace, s.Step.Commands, s.Dir, s.Timeout); errors != nil {
 			testErrors = append(testErrors, errors...)
 		}
 	}

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -120,7 +120,7 @@ func TestRunCommand(t *testing.T) {
 	}
 
 	// assert foreground cmd returns nil
-	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr)
+	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, 0)
 	assert.NoError(t, err)
 	assert.Nil(t, cmd)
 	// foreground processes should have stdout
@@ -130,11 +130,22 @@ func TestRunCommand(t *testing.T) {
 	stdout = &bytes.Buffer{}
 
 	// assert background cmd returns process
-	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, cmd)
 	// no stdout for background processes
 	assert.Empty(t, strings.TrimSpace(stdout.String()))
+
+	stdout = &bytes.Buffer{}
+	hcmd.Background = false
+	hcmd.Command = "sleep 42"
+
+	// assert foreground cmd times out
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, 2)
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "timeout"))
+	assert.Nil(t, cmd)
+
 }
 
 func TestRunCommandIgnoreErrors(t *testing.T) {
@@ -146,12 +157,12 @@ func TestRunCommandIgnoreErrors(t *testing.T) {
 	}
 
 	// assert foreground cmd returns nil
-	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr)
+	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, 0)
 	assert.NoError(t, err)
 	assert.Nil(t, cmd)
 
 	hcmd.IgnoreFailure = false
-	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, 0)
 	assert.Error(t, err)
 	assert.Nil(t, cmd)
 
@@ -160,7 +171,7 @@ func TestRunCommandIgnoreErrors(t *testing.T) {
 		Command:       "bad-command",
 		IgnoreFailure: true,
 	}
-	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, 0)
 	assert.Error(t, err)
 	assert.Nil(t, cmd)
 }


### PR DESCRIPTION
Commands now support Timeouts.  They are currently the timeout set for the TestSuite or for the TestStep.

Shortly on another PR we will add a `timeout` property to commands so that users can express individual timeouts for commands.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #20 
