### PR TITLE
KEP04: TestStep.Assert Feature

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -64,9 +64,11 @@ type TestStep struct {
 	// +kubebuilder:validation:Format:=int64
 	Index int `json:"index,omitempty"`
 
-	// files or directories to apply in the test step. Useful to reuse a number of applies across tests / test steps.
+	// Apply and Assert lists of files or directories to use in the test step.
+	// Useful to reuse a number of applies across tests / test steps.
 	// all relative paths are relative to the folder the TestStep is defined in.
 	Apply []string `json:"apply,omitempty"`
+	Assert []string `json:"assert,omitempty"`
 
 	// Objects to delete at the beginning of the test step.
 	Delete []ObjectReference `json:"delete,omitempty"`

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -67,7 +67,7 @@ type TestStep struct {
 	// Apply and Assert lists of files or directories to use in the test step.
 	// Useful to reuse a number of applies across tests / test steps.
 	// all relative paths are relative to the folder the TestStep is defined in.
-	Apply []string `json:"apply,omitempty"`
+	Apply  []string `json:"apply,omitempty"`
 	Assert []string `json:"assert,omitempty"`
 
 	// Objects to delete at the beginning of the test step.

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -497,10 +497,10 @@ func (s *Step) LoadYAML(file string) error {
 				return fmt.Errorf("step %q assert %w", s.Name, err)
 			}
 			assert, err := kfile.ToRuntimeObjects(paths)
-			asserts = append(asserts, assert...)
 			if err != nil {
 				return fmt.Errorf("step %q assert %w", s.Name, err)
 			}
+			asserts = append(asserts, assert...)
 		}
 	}
 

--- a/pkg/test/test_data/cli-test/01-patch.yaml
+++ b/pkg/test/test_data/cli-test/01-patch.yaml
@@ -2,6 +2,6 @@ apiVersion: kudo.dev/v1beta1
 kind: TestStep
 commands:
 - command: kubectl label pod cli-test-pod test=true
-  namespaced: true
+  timeout: 500
 - command: kubectl command is bad
   ignoreFailure: true

--- a/pkg/test/test_data/cli-test/01-patch.yaml
+++ b/pkg/test/test_data/cli-test/01-patch.yaml
@@ -2,6 +2,6 @@ apiVersion: kudo.dev/v1beta1
 kind: TestStep
 commands:
 - command: kubectl label pod cli-test-pod test=true
-  timeout: 500
+  namespaced: true
 - command: kubectl command is bad
   ignoreFailure: true

--- a/pkg/test/test_data/teststep-assert/00-create.yaml
+++ b/pkg/test/test_data/teststep-assert/00-create.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello2
+spec:
+  containers:
+    - image: alpine
+      name: test
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+spec:
+  containers:
+    - image: alpine
+      name: test
+---
+# using apply from TestStep from multiple folder locations
+apiVersion: kudo.dev/v1beta1
+kind: TestStep
+assert:
+  - hello1-assert.yaml
+  - hello2/hello2-assert.yaml

--- a/pkg/test/test_data/teststep-assert/00-create.yaml
+++ b/pkg/test/test_data/teststep-assert/00-create.yaml
@@ -16,7 +16,7 @@ spec:
     - image: alpine
       name: test
 ---
-# using apply from TestStep from multiple folder locations
+# using assert from TestStep from multiple folder locations
 apiVersion: kudo.dev/v1beta1
 kind: TestStep
 assert:

--- a/pkg/test/test_data/teststep-assert/hello1-assert.yaml
+++ b/pkg/test/test_data/teststep-assert/hello1-assert.yaml
@@ -1,0 +1,7 @@
+# Verify that the pods were created.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+status:
+  phase: Pending

--- a/pkg/test/test_data/teststep-assert/hello2/hello2-assert.yaml
+++ b/pkg/test/test_data/teststep-assert/hello2/hello2-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello2
+status:
+  phase: Pending


### PR DESCRIPTION
TestStep has an `assert` property added which is a list of files.
As stated in KEP04, this will allow the reuse of files in multiple test steps.   This provides a more concise way of expressing this common need.

Example:  `00-create.yaml`

```
apiVersion: kudo.dev/v1beta1
kind: TestStep
assert:
  - hello1-assert.yaml
  - hello2/hello2-assert.yaml
```
All the options above have been tested.  The relative path is relative to the step folder the TestStep is in.


Signed-off-by: Ken Sipe <kensipe@gmail.com>
