### PR TITLE
KEP04: TestStep.Error Feature

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -64,11 +64,12 @@ type TestStep struct {
 	// +kubebuilder:validation:Format:=int64
 	Index int `json:"index,omitempty"`
 
-	// Apply and Assert lists of files or directories to use in the test step.
+	// Apply, Assert and Error lists of files or directories to use in the test step.
 	// Useful to reuse a number of applies across tests / test steps.
 	// all relative paths are relative to the folder the TestStep is defined in.
 	Apply  []string `json:"apply,omitempty"`
 	Assert []string `json:"assert,omitempty"`
+	Error []string `json:"error,omitempty"`
 
 	// Objects to delete at the beginning of the test step.
 	Delete []ObjectReference `json:"delete,omitempty"`

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -69,7 +69,7 @@ type TestStep struct {
 	// all relative paths are relative to the folder the TestStep is defined in.
 	Apply  []string `json:"apply,omitempty"`
 	Assert []string `json:"assert,omitempty"`
-	Error []string `json:"error,omitempty"`
+	Error  []string `json:"error,omitempty"`
 
 	// Objects to delete at the beginning of the test step.
 	Delete []ObjectReference `json:"delete,omitempty"`

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -491,6 +491,7 @@ func (s *Step) LoadYAML(file string) error {
 			}
 			applies = append(applies, apply...)
 		}
+		// process configured step asserts
 		for _, assertPath := range s.Step.Assert {
 			paths, err := kfile.FromPath(filepath.Join(s.Dir, assertPath), "*.yaml")
 			if err != nil {
@@ -501,6 +502,18 @@ func (s *Step) LoadYAML(file string) error {
 				return fmt.Errorf("step %q assert %w", s.Name, err)
 			}
 			asserts = append(asserts, assert...)
+		}
+		// process configured errors
+		for _, errorPath := range s.Step.Error {
+			paths, err := kfile.FromPath(filepath.Join(s.Dir, errorPath), "*.yaml")
+			if err != nil {
+				return fmt.Errorf("step %q error %w", s.Name, err)
+			}
+			errObjs, err := kfile.ToRuntimeObjects(paths)
+			if err != nil {
+				return fmt.Errorf("step %q error %w", s.Name, err)
+			}
+			s.Errors = append(s.Errors, errObjs...)
 		}
 	}
 

--- a/pkg/test/test_data/cli-test/01-patch.yaml
+++ b/pkg/test/test_data/cli-test/01-patch.yaml
@@ -2,6 +2,6 @@ apiVersion: kudo.dev/v1beta1
 kind: TestStep
 commands:
 - command: kubectl label pod cli-test-pod test=true
-  namespaced: true
+  timeout: 500
 - command: kubectl command is bad
   ignoreFailure: true

--- a/pkg/test/test_data/cli-test/01-patch.yaml
+++ b/pkg/test/test_data/cli-test/01-patch.yaml
@@ -2,6 +2,6 @@ apiVersion: kudo.dev/v1beta1
 kind: TestStep
 commands:
 - command: kubectl label pod cli-test-pod test=true
-  timeout: 500
+  namespaced: true
 - command: kubectl command is bad
   ignoreFailure: true

--- a/pkg/test/test_data/teststep-errors/00-assert.yaml
+++ b/pkg/test/test_data/teststep-errors/00-assert.yaml
@@ -1,0 +1,14 @@
+# Verify that the pods were created.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+status:
+  phase: Pending
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello2
+status:
+  phase: Pending

--- a/pkg/test/test_data/teststep-errors/00-create.yaml
+++ b/pkg/test/test_data/teststep-errors/00-create.yaml
@@ -1,0 +1,18 @@
+# Create some pods. Pod specs are immutable, so we can use these to verify that the resources were deleted.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+spec:
+  containers:
+  - image: alpine
+    name: test
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello2
+spec:
+  containers:
+  - image: alpine
+    name: test

--- a/pkg/test/test_data/teststep-errors/01-delete-error-check.yaml
+++ b/pkg/test/test_data/teststep-errors/01-delete-error-check.yaml
@@ -1,0 +1,8 @@
+apiVersion: kudo.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: v1
+    kind: Pod
+error:
+  - hello1-error.yaml
+  - hello2/hello2-error.yaml

--- a/pkg/test/test_data/teststep-errors/hello1-error.yaml
+++ b/pkg/test/test_data/teststep-errors/hello1-error.yaml
@@ -1,0 +1,7 @@
+# Verify that the pods were created.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+status:
+  phase: Pending

--- a/pkg/test/test_data/teststep-errors/hello2/hello2-error.yaml
+++ b/pkg/test/test_data/teststep-errors/hello2/hello2-error.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello2
+status:
+  phase: Pending


### PR DESCRIPTION
TestStep has an `error` property added which is a list of files.
As stated in KEP04, this will allow the reuse of files in multiple test steps.   This provides a more concise way of expressing this common need.

Example:  `01-delete-error.check.yaml`

```
apiVersion: kudo.dev/v1beta1
kind: TestStep
delete:
  - apiVersion: v1
    kind: Pod
error:
  - hello1-error.yaml
  - hello2/hello2-error.yaml
```

All the options above have been tested.  The relative path is relative to the step folder the TestStep is in.


Signed-off-by: Ken Sipe <kensipe@gmail.com>
