### PR TITLE
Command Timeout Override

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -109,6 +109,8 @@ type Command struct {
 	IgnoreFailure bool `json:"ignoreFailure"`
 	// If set, the command is run in the background.
 	Background bool `json:"background"`
+	// Override the TestSuite timeout for this command (in seconds).
+	Timeout int `json:"timeout"`
 }
 
 // DefaultKINDContext defines the default kind context to use.

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -981,6 +981,20 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 	kudoENV["KUBECONFIG"] = fmt.Sprintf("%s/kubeconfig", actualDir)
 	kudoENV["PATH"] = fmt.Sprintf("%s/bin/:%s", actualDir, os.Getenv("PATH"))
 
+	// by default testsuite timeout is the command timeout
+	// 0 is allowed for testsuite which means forever (or no timeout)
+	// cmd.timeout defaults to 0 and is NOT and explicit override to mean forever.
+	// using a negative value for cmd.timeout is an override of testsuite.timeout to mean forever
+	// if testsuite.timeout is set,  set cmd.timeout = -1 (means no timeout), 0 (default) means using testsuite.timeout, and anything else is an override of time.
+	// if testsuite.timeout = 0, cmd.timeout -1 and 0 means forever
+	if cmd.Timeout < 0 {
+		// negative is always forever
+		timeout = 0
+	}
+	if cmd.Timeout > 0 {
+		timeout = cmd.Timeout
+	}
+
 	// command context is provided context or a cancel context but only from cmds that are not background
 	cmdCtx := ctx
 	if timeout > 0 && !cmd.Background {

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -146,6 +146,17 @@ func TestRunCommand(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "timeout"))
 	assert.Nil(t, cmd)
 
+	stdout = &bytes.Buffer{}
+	hcmd.Background = false
+	hcmd.Command = "sleep 42"
+	hcmd.Timeout = 2
+
+	// assert foreground cmd times out with command timeout
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, 0)
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "timeout"))
+	assert.Nil(t, cmd)
+
 }
 
 func TestRunCommandIgnoreErrors(t *testing.T) {


### PR DESCRIPTION
Adds the ability to override the testsuite timeout for a specific command.

it is possible to specify a `timeout` when specifying a timeout (for a testsuite or teststep)
```
commands:
  - command: kubectl label pod cli-test-pod test=true
     timeout: 5
```

This example would reduce the timeout of 30 secs defined by the testsuite to 5 secs.
If the you want to remove a timeout then use a negative number `timeout: -1` 


Signed-off-by: Ken Sipe <kensipe@gmail.com>

