### PR TITLE
Commands can Opt-out of Logging

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -114,6 +114,8 @@ type Command struct {
 	Background bool `json:"background"`
 	// Override the TestSuite timeout for this command (in seconds).
 	Timeout int `json:"timeout"`
+	// If set, the command is NOT logged.  Useful to sensitive logs or to reduce noise.
+	IgnoreLog bool `json:"ignorelog"`
 }
 
 // DefaultKINDContext defines the default kind context to use.

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -114,8 +114,8 @@ type Command struct {
 	Background bool `json:"background"`
 	// Override the TestSuite timeout for this command (in seconds).
 	Timeout int `json:"timeout"`
-	// If set, the command is NOT logged.  Useful to sensitive logs or to reduce noise.
-	IgnoreLog bool `json:"ignorelog"`
+	// If set, the output from the command is NOT logged.  Useful for sensitive logs or to reduce noise.
+	SkipLogOutput bool `json:"skipLogOutput"`
 }
 
 // DefaultKINDContext defines the default kind context to use.

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1011,8 +1011,10 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 	logger.Logf("running command: %v", builtCmd.Args)
 
 	builtCmd.Dir = cwd
-	builtCmd.Stdout = stdout
-	builtCmd.Stderr = stderr
+	if !cmd.IgnoreLog {
+		builtCmd.Stdout = stdout
+		builtCmd.Stderr = stderr
+	}
 	builtCmd.Env = os.Environ()
 	for key, value := range kudoENV {
 		builtCmd.Env = append(builtCmd.Env, fmt.Sprintf("%s=%s", key, value))

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1011,7 +1011,7 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 	logger.Logf("running command: %v", builtCmd.Args)
 
 	builtCmd.Dir = cwd
-	if !cmd.IgnoreLog {
+	if !cmd.SkipLogOutput {
 		builtCmd.Stdout = stdout
 		builtCmd.Stderr = stderr
 	}

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -188,3 +188,27 @@ func TestRunCommandIgnoreErrors(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, cmd)
 }
+
+func TestRunCommandIgnoreLog(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	hcmd := harness.Command{
+		Command: "echo 'test'",
+	}
+
+	logger := NewTestLogger(t, "")
+	// test there is a stdout
+	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0)
+	assert.NoError(t, err)
+	assert.Nil(t, cmd)
+	assert.True(t, stdout.Len() > 0)
+
+	hcmd.IgnoreLog = true
+	stdout = &bytes.Buffer{}
+	stderr = &bytes.Buffer{}
+	// test there is no stdout
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0)
+	assert.NoError(t, err)
+	assert.Nil(t, cmd)
+	assert.True(t, stdout.Len() == 0)
+}

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -189,7 +189,7 @@ func TestRunCommandIgnoreErrors(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
-func TestRunCommandIgnoreLog(t *testing.T) {
+func TestRunCommandSkipLogOutput(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	hcmd := harness.Command{
@@ -203,7 +203,7 @@ func TestRunCommandIgnoreLog(t *testing.T) {
 	assert.Nil(t, cmd)
 	assert.True(t, stdout.Len() > 0)
 
-	hcmd.IgnoreLog = true
+	hcmd.SkipLogOutput = true
 	stdout = &bytes.Buffer{}
 	stderr = &bytes.Buffer{}
 	// test there is no stdout


### PR DESCRIPTION
Provides the ability for a command to opt-out of logging.

This is useful when:
1. log may have sensitive information
2. log is too noisy due to a specific command

Co-authored-by: Marcin Owsiany <mowsiany@D2iQ.com>
Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #
