### PR TITLE
Command Scripts from TestSuite or TestStep

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -2,4 +2,4 @@ apiVersion: kudo.dev/v1beta1
 kind: TestSuite
 parallel: 4
 timeout: 120
-startControlPlane: true
+

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -2,4 +2,4 @@ apiVersion: kudo.dev/v1beta1
 kind: TestSuite
 parallel: 4
 timeout: 120
-
+startControlPlane: true

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -108,6 +108,8 @@ type Command struct {
 	Command string `json:"command"`
 	// If set, the `--namespace` flag will be appended to the command with the namespace to use.
 	Namespaced bool `json:"namespaced"`
+	// Ability to run a script from TestStep (without a script file)
+	Script string `json:"script"`
 	// If set, exit failures (`exec.ExitError`) will be ignored. `exec.Error` are NOT ignored.
 	IgnoreFailure bool `json:"ignoreFailure"`
 	// If set, the command is run in the background.

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -108,7 +108,9 @@ type Command struct {
 	Command string `json:"command"`
 	// If set, the `--namespace` flag will be appended to the command with the namespace to use.
 	Namespaced bool `json:"namespaced"`
-	// Ability to run a script from TestStep (without a script file)
+	// Ability to run a shell script from TestStep (without a script file)
+	// namespaced and command should not be used with script.  namespaced is ignored and command is an error.
+	// env expansion is depended upon the shell but ENV is passed to the runtime env.
 	Script string `json:"script"`
 	// If set, exit failures (`exec.ExitError`) will be ignored. `exec.Error` are NOT ignored.
 	IgnoreFailure bool `json:"ignoreFailure"`

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -938,6 +938,17 @@ func ExpandEnv(c string, env map[string]string) string {
 func GetArgs(ctx context.Context, cmd harness.Command, namespace string, env map[string]string) (*exec.Cmd, error) {
 	argSlice := []string{}
 
+	if cmd.Command != "" && cmd.Script != "" {
+		return nil, errors.New("command and script can not be set in the same configuration")
+	}
+	if cmd.Command == "" && cmd.Script == "" {
+		return nil, errors.New("command or script must be configured")
+	}
+
+	if cmd.Script != "" {
+		builtCmd := exec.CommandContext(ctx, "sh", "-c", cmd.Script)
+		return builtCmd, nil
+	}
 	c := ExpandEnv(cmd.Command, env)
 
 	argSplit, err := shlex.Split(c)

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -942,7 +942,10 @@ func GetArgs(ctx context.Context, cmd harness.Command, namespace string, env map
 		return nil, errors.New("command and script can not be set in the same configuration")
 	}
 	if cmd.Command == "" && cmd.Script == "" {
-		return nil, errors.New("command or script must be configured")
+		return nil, errors.New("command or script must be set")
+	}
+	if cmd.Script != "" && cmd.Namespaced {
+		return nil, errors.New("script can not used 'namespaced', use the $NAMESPACE environment variable instead")
 	}
 
 	if cmd.Script != "" {


### PR DESCRIPTION
Previously scripts added to `command:` would fail such as:
```
commands:
  - command: for i in {1..5}; do echo $NAMESPACE; done
  - command: sh -c "for i in {1..5}; do echo $NAMESPACE; done"
```
Both of these options fail... to provide some ability to script a `script:` is provided as a commands option such as:

```
commands:
  - script: for i in {1..5}; do echo $NAMESPACE; done
``` 

This works for TestSuite and TestStep

Fixes: #50 

Co-authored-by: Marcin Owsiany <mowsiany@D2iQ.com>
Co-authored-by: Andreas Neumann <aneumann@mesosphere.com>
Signed-off-by: Ken Sipe <kensipe@gmail.com>
