### PR TITLE
teststep apply, assert and errors can now take urls, files or folder

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -2,3 +2,4 @@ apiVersion: kudo.dev/v1beta1
 kind: TestSuite
 parallel: 4
 timeout: 120
+startControlPlane: true

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -2,4 +2,3 @@ apiVersion: kudo.dev/v1beta1
 kind: TestSuite
 parallel: 4
 timeout: 120
-startControlPlane: true

--- a/pkg/file/files.go
+++ b/pkg/file/files.go
@@ -16,7 +16,7 @@ func ToRuntimeObjects(paths []string) ([]runtime.Object, error) {
 	apply := []runtime.Object{}
 
 	for _, path := range paths {
-		objs, err := testutils.LoadYAML(path)
+		objs, err := testutils.LoadYAMLFromFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("file %q load yaml error", path)
 		}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1,0 +1,57 @@
+package http
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	coreHTTP "net/http"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
+)
+
+// IsURL returns true if string is an URL
+func IsURL(str string) bool {
+	u, err := url.Parse(str)
+	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+// ToRuntimeObjects takes a url, pulls the file and returns  []runtime.Object
+// url must be a full path to a manifest file.  that file can have multiple runtime objects.
+func ToRuntimeObjects(urlPath string) ([]runtime.Object, error) {
+	apply := []runtime.Object{}
+
+	buf, err := Read(urlPath)
+	if err != nil {
+		return nil, err
+	}
+
+	objs, err := testutils.LoadYAML(urlPath, buf)
+	if err != nil {
+		return nil, fmt.Errorf("url %q load yaml error", urlPath)
+	}
+	apply = append(apply, objs...)
+
+	return apply, nil
+}
+
+// Read returns a buffer for the file at the url
+func Read(urlPath string) (*bytes.Buffer, error) {
+
+	response, err := coreHTTP.Get(urlPath) // nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	if response != nil {
+		defer response.Body.Close()
+	}
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &buf, nil
+}

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -1,0 +1,43 @@
+package http
+
+import (
+	"testing"
+)
+
+func TestIsURL(t *testing.T) {
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			"path to folder",
+			"/opt/foo",
+			false,
+		},
+		{
+			"path to file",
+			"/opt/foo.txt",
+			false,
+		},
+		{
+			"http to file",
+			"http://kuttl.dev/foo.txt",
+			true,
+		},
+		{
+			"https to file",
+			"https://kuttl.dev/foo.txt",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsURL(tt.path); got != tt.want {
+				t.Errorf("IsURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -80,7 +80,7 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 
 			// Load the configuration YAML into options.
 			if configPath != "" {
-				objects, err := testutils.LoadYAML(configPath)
+				objects, err := testutils.LoadYAMLFromFile(configPath)
 				if err != nil {
 					return err
 				}

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -158,7 +158,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	objs, err := LoadYAML(tmpfile.Name())
+	objs, err := LoadYAMLFromFile(tmpfile.Name())
 	assert.Nil(t, err)
 
 	assert.Equal(t, &unstructured.Unstructured{
@@ -227,7 +227,7 @@ metadata:
 		t.Fatal(err)
 	}
 
-	objs, err := LoadYAML(tmpfile.Name())
+	objs, err := LoadYAMLFromFile(tmpfile.Name())
 	assert.Nil(t, err)
 
 	crd := NewResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "", "")


### PR DESCRIPTION
TestStep Apply, Errors and Asserts can now have urls (in addition to folders and files)

```
apiVersion: kudo.dev/v1beta1
kind: TestStep
apply:
  - https://mesosphere.github.io/kubeaddons/bundle.yaml
```
Is completely legit now.

There was an interesting situation with the kubeaddons url as well.  It has a file headers of:

```
# DO NOT EDIT: this file is generated

---
apiVersion: apiextensions.k8s.io/v1beta1
```

The 3 lines prior to the separator creates an unstructured object (without an error) but isn't valid.  This need detection has been added to the code as well.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #114 
