### PR TITLE
Command Expansion for TestStep Apply, Assert and Error

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,38 @@
+package env
+
+import (
+	"os"
+	"strings"
+)
+
+// Expand provides OS expansion of defined ENV VARs inside args to commands.  The expansion is limited to what is defined on the OS
+// and the variables passed into to the env parameter. To escape a dollar sign, pass in two dollar signs.
+func ExpandWithMap(c string, env map[string]string) string {
+	// expand $$ -> $
+	fullEnv := map[string]string{
+		"$": "$",
+	}
+
+	// add all OS environment variables to the map
+	for _, envVar := range os.Environ() {
+		splitVar := strings.SplitN(envVar, "=", 2)
+		if len(splitVar) != 2 {
+			continue
+		}
+		fullEnv[splitVar[0]] = splitVar[1]
+	}
+
+	// add env parameter variables to map
+	for k, v := range env {
+		fullEnv[k] = v
+	}
+
+	return os.Expand(c, func(s string) string {
+		return fullEnv[s]
+	})
+}
+
+// Expand provides shell expansion similar to ExpandWithMap without the map extension.  It is os.Env only.
+func Expand(c string) string {
+	return ExpandWithMap(c, nil)
+}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -9,9 +9,13 @@ import (
 
 func TestExpandWithMap(t *testing.T) {
 	os.Setenv("KUTTL_TEST_123", "hello")
+	defer func() {
+		os.Unsetenv("KUTTL_TEST_123")
+	}()
 	assert.Equal(t, "hello $  world", ExpandWithMap("$KUTTL_TEST_123 $$ $DOES_NOT_EXIST_1234 ${EXPAND_ME}", map[string]string{
 		"EXPAND_ME": "world",
 	}))
+
 }
 
 func TestExpand(t *testing.T) {
@@ -50,5 +54,4 @@ func TestExpand(t *testing.T) {
 
 		})
 	}
-	//assert.Equal(t, "hello $  ", Expand("$KUTTL_TEST_123 $$ $DOES_NOT_EXIST_1234 ${EXPAND_ME}"))
 }

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -1,0 +1,54 @@
+package env
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandWithMap(t *testing.T) {
+	os.Setenv("KUTTL_TEST_123", "hello")
+	assert.Equal(t, "hello $  world", ExpandWithMap("$KUTTL_TEST_123 $$ $DOES_NOT_EXIST_1234 ${EXPAND_ME}", map[string]string{
+		"EXPAND_ME": "world",
+	}))
+}
+
+func TestExpand(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: `do not expand $$`,
+			in:   "test $$",
+			want: "test $",
+		},
+		{
+			name: `expand os`,
+			in:   "$KUTTL_TEST_123 $$",
+			want: "hello $",
+		},
+		{
+			name: `expansions with no values, have no output`,
+			in:   "$KUTTL_TEST_123 $$ ${NOT_PROVIDED}",
+			want: "hello $ ",
+		},
+	}
+
+	os.Setenv("KUTTL_TEST_123", "hello")
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+
+			got := Expand(tt.in)
+
+			if got != tt.want {
+				t.Errorf(`(%v) = %q; want "%v"`, tt.in, got, tt.want)
+			}
+
+		})
+	}
+	//assert.Equal(t, "hello $  ", Expand("$KUTTL_TEST_123 $$ $DOES_NOT_EXIST_1234 ${EXPAND_ME}"))
+}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	harness "github.com/kudobuilder/kuttl/pkg/apis/testharness/v1beta1"
+	"github.com/kudobuilder/kuttl/pkg/env"
 	kfile "github.com/kudobuilder/kuttl/pkg/file"
 	"github.com/kudobuilder/kuttl/pkg/http"
 	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
@@ -482,7 +483,8 @@ func (s *Step) LoadYAML(file string) error {
 	if s.Step != nil {
 		// process configured step applies
 		for _, applyPath := range s.Step.Apply {
-			apply, err := runtimeObjectsFromPath(s, applyPath)
+			exApply := env.Expand(applyPath)
+			apply, err := runtimeObjectsFromPath(s, exApply)
 			if err != nil {
 				return err
 			}
@@ -490,7 +492,8 @@ func (s *Step) LoadYAML(file string) error {
 		}
 		// process configured step asserts
 		for _, assertPath := range s.Step.Assert {
-			assert, err := runtimeObjectsFromPath(s, assertPath)
+			exAssert := env.Expand(assertPath)
+			assert, err := runtimeObjectsFromPath(s, exAssert)
 			if err != nil {
 				return err
 			}
@@ -498,7 +501,8 @@ func (s *Step) LoadYAML(file string) error {
 		}
 		// process configured errors
 		for _, errorPath := range s.Step.Error {
-			errObjs, err := runtimeObjectsFromPath(s, errorPath)
+			exError := env.Expand(errorPath)
+			errObjs, err := runtimeObjectsFromPath(s, exError)
 			if err != nil {
 				return err
 			}

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -342,12 +342,26 @@ func TestCheckedTypeAssertions(t *testing.T) {
 	}
 }
 
+func TestApplyExpansion(t *testing.T) {
+	os.Setenv("TEST_FOO", "test")
+	defer func() {
+		os.Unsetenv("TEST_FOO")
+	}()
+
+	step := Step{Dir: "step_integration_test_data/assert_expand/"}
+	path := "step_integration_test_data/assert_expand/00-step1.yaml"
+	err := step.LoadYAML(path)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(step.Apply))
+
+}
+
 func TestTwoTestStepping(t *testing.T) {
 	apply := []runtime.Object{}
 	step := &Step{
-		Name:            "twostepping",
-		Index:           0,
-		Apply:           apply,
+		Name:  "twostepping",
+		Index: 0,
+		Apply: apply,
 	}
 
 	// 2 apply files in 1 step
@@ -358,11 +372,10 @@ func TestTwoTestStepping(t *testing.T) {
 
 	// 2 teststeps in 1 file in 1 step
 	step = &Step{
-		Name:            "twostepping",
-		Index:           0,
-		Apply:           apply,
+		Name:  "twostepping",
+		Index: 0,
+		Apply: apply,
 	}
 	err = step.LoadYAML("step_integration_test_data/two_step/01-step1.yaml")
 	assert.Error(t, err, "more than 1 TestStep not allowed in step \"twostepping\"")
 }
-

--- a/pkg/test/step_integration_test_data/assert_expand/00-step1.yaml
+++ b/pkg/test/step_integration_test_data/assert_expand/00-step1.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+apply:
+  - ${TEST_FOO}/test.yaml

--- a/pkg/test/step_integration_test_data/assert_expand/test/test.yaml
+++ b/pkg/test/step_integration_test_data/assert_expand/test/test.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  labels:
+    app: nginx
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.7.9

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -409,13 +409,6 @@ func TestGetKubectlArgs(t *testing.T) {
 	}
 }
 
-func TestExpandEnv(t *testing.T) {
-	os.Setenv("KUTTL_TEST_123", "hello")
-	assert.Equal(t, "hello $  world", ExpandEnv("$KUTTL_TEST_123 $$ $DOES_NOT_EXIST_1234 ${EXPAND_ME}", map[string]string{
-		"EXPAND_ME": "world",
-	}))
-}
-
 func TestRunScript(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
It is now possible to have a TestStep with command expansions:

```
apiVersion: kuttl.dev/v1beta1
kind: TestStep
timeout: 30
apply:
  - ${TEST_FOO}/test.yaml
assert:
  - $TEST_FOO/test.yaml
```

Fixes #131 
