### PR TITLE
Assert Command

### DIFF
--- a/pkg/kuttlctl/cmd/assert.go
+++ b/pkg/kuttlctl/cmd/assert.go
@@ -40,10 +40,7 @@ func newAssertCmd() *cobra.Command {
 				return errors.New("one file argument is required")
 
 			}
-			if len(args) != 1 {
-				return errors.New("only one file argument is valid")
-			}
-			return test.Assert(args[0], namespace, timeout)
+			return test.Assert(namespace, timeout, args...)
 		},
 	}
 

--- a/pkg/kuttlctl/cmd/assert.go
+++ b/pkg/kuttlctl/cmd/assert.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	harness "github.com/kudobuilder/kuttl/pkg/apis/testharness/v1beta1"
+	"github.com/kudobuilder/kuttl/pkg/test"
+	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
+)
+
+var (
+	assertExample = `  # Asserts against a $KUBECONFIG cluster the values defined in the assert file.
+  kubectl kuttl assert <path/to/assertfile.yaml>`
+)
+
+// newAssertCmd returns a new initialized instance of the assert sub command
+func newAssertCmd() *cobra.Command {
+	timeout := 30
+	options := harness.TestSuite{}
+
+	assertCmd := &cobra.Command{
+		Use:     "assert",
+		Short:   "Asserts the declared state to be true.",
+		Long:    `Asserts the declared state provided as an argument to be true in the $KUBECONFIG cluster. Valid arguments are a YAML file, URL to a YAML file.`,
+		Example: assertExample,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+			options.TestDirs = args
+
+			if isSet(flags, "timeout") {
+				options.Timeout = timeout
+			}
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			testutils.RunTests("kuttl", "assert-cmd", 1, func(t *testing.T) {
+				harness := test.Harness{
+					TestSuite: options,
+					T:         t,
+				}
+				//step.goL349
+				harness.Run()
+			})
+		},
+	}
+
+	assertCmd.Flags().IntVar(&timeout, "timeout", 30, "The timeout to use as default for TestSuite configuration.")
+
+	return assertCmd
+}

--- a/pkg/kuttlctl/cmd/root.go
+++ b/pkg/kuttlctl/cmd/root.go
@@ -24,6 +24,7 @@ and serves as an API aggregation layer.
 		Version: version.Get().GitVersion,
 	}
 
+	cmd.AddCommand(newAssertCmd())
 	cmd.AddCommand(newTestCmd())
 	cmd.AddCommand(newVersionCmd())
 

--- a/pkg/test/assert.go
+++ b/pkg/test/assert.go
@@ -1,0 +1,87 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
+)
+
+// Assert
+func Assert(assertFile, namespace string, timeout int) error {
+
+	info, err := os.Stat(assertFile)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("the file %q does not exist", assertFile)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%q is a directory and not a file", assertFile)
+	}
+	// feels like the wrong abstraction, need to do some refactoring
+	s := &Step{
+		Timeout:         0,
+		Client:          Client,
+		DiscoveryClient: DiscoveryClient,
+	}
+
+	objects, err := testutils.LoadYAMLFromFile(assertFile)
+	if err != nil {
+		return err
+	}
+
+	var testErrors []error
+	for i := 0; i < timeout; i++ {
+		// start fresh
+		testErrors = []error{}
+		for _, expected := range objects {
+			testErrors = append(testErrors, s.CheckResource(expected, namespace)...)
+		}
+
+		if len(testErrors) == 0 {
+			break
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	if len(testErrors) == 0 {
+		fmt.Printf("%q in the %q namespace is valid\n", assertFile, namespace)
+		return nil
+	}
+
+	for _, testError := range testErrors {
+		fmt.Println(testError)
+	}
+	return fmt.Errorf("%q in the %q namespace is not valid", assertFile, namespace)
+}
+
+func Client(forceNew bool) (client.Client, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := testutils.NewRetryClient(cfg, client.Options{
+		Scheme: testutils.Scheme(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fatal error getting client: %v", err)
+	}
+	return client, nil
+}
+
+func DiscoveryClient() (discovery.DiscoveryInterface, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	dclient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("fatal error getting discovery client: %v", err)
+	}
+	return dclient, nil
+}


### PR DESCRIPTION
Assert command added which provides the ability to assert a manifest file on a cluster.  This is convenient when manually modifying a cluster and looking to assert that it is valid, or when creating an assert file.

when successful
```
go run cmd/kubectl-kuttl/main.go assert --timeout 1 test.yaml
"test.yaml" in "default" namespace is valid
```

when there is an assert failure
```
go run cmd/kubectl-kuttl/main.go assert --timeout 1 test.yaml -n temp
--- Pod:temp/foo
+++ Pod:temp/foo
@@ -1,8 +1,144 @@
 apiVersion: v1
 kind: Pod
 metadata:
+  labels:
+    run: foo
+  managedFields:
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:run: {}
+      f:spec:
+        f:containers:
+          k:{"name":"foo"}:
+            .: {}
+            f:image: {}
+            f:imagePullPolicy: {}
+            f:name: {}
+            f:resources: {}
+            f:terminationMessagePath: {}
+            f:terminationMessagePolicy: {}
+        f:dnsPolicy: {}
+        f:enableServiceLinks: {}
+        f:restartPolicy: {}
+        f:schedulerName: {}
+        f:securityContext: {}
+        f:terminationGracePeriodSeconds: {}
+    manager: kubectl
+    operation: Update
+    time: "2020-06-16T03:14:48Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        f:conditions:
+          k:{"type":"ContainersReady"}:
+            .: {}
+            f:lastProbeTime: {}
+            f:lastTransitionTime: {}
+            f:status: {}
+            f:type: {}
+          k:{"type":"Initialized"}:
+            .: {}
+            f:lastProbeTime: {}
+            f:lastTransitionTime: {}
+            f:status: {}
+            f:type: {}
+          k:{"type":"Ready"}:
+            .: {}
+            f:lastProbeTime: {}
+            f:lastTransitionTime: {}
+            f:status: {}
+            f:type: {}
+        f:containerStatuses: {}
+        f:hostIP: {}
+        f:phase: {}
+        f:podIP: {}
+        f:podIPs:
+          .: {}
+          k:{"ip":"10.244.0.6"}:
+            .: {}
+            f:ip: {}
+        f:startTime: {}
+    manager: kubelet
+    operation: Update
+    time: "2020-06-16T03:14:50Z"
   name: foo
   namespace: temp
+spec:
+  containers:
+  - image: nginx
+    imagePullPolicy: Always
+    name: foo
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-cfsjm
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: kind-control-plane
+  priority: 0
+  restartPolicy: Never
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: default-token-cfsjm
+    secret:
+      defaultMode: 420
+      secretName: default-token-cfsjm
 status:
-  phase: Run
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2020-06-16T03:14:48Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2020-06-16T03:14:50Z"
+    status: "True"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2020-06-16T03:14:50Z"
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2020-06-16T03:14:48Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: containerd://687e796bee7ba4870ca3c24a8c98fe4247e602ebc1534555350424c21713b802
+    image: docker.io/library/nginx:latest
+    imageID: docker.io/library/nginx@sha256:21f32f6c08406306d822a0e6e8b7dc81f53f336570e852e25fbe1e3e3d0d0133
+    lastState: {}
+    name: foo
+    ready: true
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2020-06-16T03:14:49Z"
+  hostIP: 172.18.0.2
+  phase: Running
+  podIP: 10.244.0.6
+  podIPs:
+  - ip: 10.244.0.6
+  qosClass: BestEffort
+  startTime: "2020-06-16T03:14:48Z"
 

resource Pod:temp/foo: .status.phase: value mismatch, expected: Run != actual: Running
```
Fixes #125 
