### PR TITLE
Assert Cmd Enhancement

### DIFF
--- a/pkg/kuttlctl/cmd/assert.go
+++ b/pkg/kuttlctl/cmd/assert.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	harness "github.com/kudobuilder/kuttl/pkg/apis/testharness/v1beta1"
 	"github.com/kudobuilder/kuttl/pkg/test"
 )
 
@@ -19,22 +18,11 @@ func newAssertCmd() *cobra.Command {
 	timeout := 5
 	namespace := "default"
 
-	options := harness.TestSuite{}
-
 	assertCmd := &cobra.Command{
 		Use:     "assert",
 		Short:   "Asserts the declared state to be true.",
 		Long:    `Asserts the declared state provided as an argument to be true in the $KUBECONFIG cluster. Valid arguments are a YAML file, URL to a YAML file.`,
 		Example: assertExample,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			flags := cmd.Flags()
-			options.TestDirs = args
-
-			if isSet(flags, "timeout") {
-				options.Timeout = timeout
-			}
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("one file argument is required")

--- a/pkg/test/assert.go
+++ b/pkg/test/assert.go
@@ -3,7 +3,6 @@ package test
 import (
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,15 +19,7 @@ func Assert(namespace string, timeout int, assertFiles ...string) error {
 	var objects []runtime.Object
 
 	for _, file := range assertFiles {
-		info, err := os.Stat(file)
-		if os.IsNotExist(err) {
-			return fmt.Errorf("the file %q does not exist", file)
-		}
-		if info.IsDir() {
-			return fmt.Errorf("%q is a directory and not a file", file)
-		}
-
-		o, err := testutils.LoadYAMLFromFile(file)
+		o, err := RuntimeObjectsFromPath(file, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -486,7 +486,7 @@ func (s *Step) LoadYAML(file string) error {
 			exApply := env.Expand(applyPath)
 			apply, err := RuntimeObjectsFromPath(exApply, s.Dir)
 			if err != nil {
-				return fmt.Errorf("step %q apply %w", s.Name, err)
+				return fmt.Errorf("step %q apply path %s: %w", s.Name, exApply, err)
 			}
 			applies = append(applies, apply...)
 		}
@@ -495,7 +495,7 @@ func (s *Step) LoadYAML(file string) error {
 			exAssert := env.Expand(assertPath)
 			assert, err := RuntimeObjectsFromPath(exAssert, s.Dir)
 			if err != nil {
-				return fmt.Errorf("step %q apply %w", s.Name, err)
+				return fmt.Errorf("step %q assert path %s: %w", s.Name, exAssert, err)
 			}
 			asserts = append(asserts, assert...)
 		}
@@ -504,7 +504,7 @@ func (s *Step) LoadYAML(file string) error {
 			exError := env.Expand(errorPath)
 			errObjs, err := RuntimeObjectsFromPath(exError, s.Dir)
 			if err != nil {
-				return fmt.Errorf("step %q apply %w", s.Name, err)
+				return fmt.Errorf("step %q error path %s: %w", s.Name, exError, err)
 			}
 			s.Errors = append(s.Errors, errObjs...)
 		}


### PR DESCRIPTION
Removed unnecessary code.
Noticed that the cmd help docs indicated the desire to use urls for assert files, changed the code to support that.

```
go run cmd/kubectl-kuttl/main.go assert -n temp http://localhost:8000/test.yaml --timeout 2
assert is valid
```
Signed-off-by: Ken Sipe <kensipe@gmail.com>
