### PR TITLE
Errors Command

### DIFF
--- a/pkg/kuttlctl/cmd/errors.go
+++ b/pkg/kuttlctl/cmd/errors.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	errorsExample = `  # Asserts "errors" against a $KUBECONFIG cluster the values defined in the assert file.
-  kubectl kuttl errors <path/to/errorsfile.yaml>`
+  kubectl kuttl errors <path/to/errorsfile.yaml> <path/to/errorsfile.yaml>...`
 )
 
 // newErrorsCmd returns a new initialized instance of the errors sub command

--- a/pkg/kuttlctl/cmd/errors.go
+++ b/pkg/kuttlctl/cmd/errors.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 
 	"github.com/spf13/cobra"
+
+	"github.com/kudobuilder/kuttl/pkg/test"
 )
 
 var (
@@ -26,7 +28,7 @@ func newErrorsCmd() *cobra.Command {
 				return errors.New("one file argument is required")
 
 			}
-			return nil
+			return test.Errors(namespace, timeout, args...)
 		},
 	}
 

--- a/pkg/kuttlctl/cmd/errors.go
+++ b/pkg/kuttlctl/cmd/errors.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	errorsExample = `  # Asserts "errors" against a $KUBECONFIG cluster the values defined in the assert file.
+  kubectl kuttl errors <path/to/errorsfile.yaml>`
+)
+
+// newErrorsCmd returns a new initialized instance of the errors sub command
+func newErrorsCmd() *cobra.Command {
+	timeout := 5
+	namespace := "default"
+
+	errorsCmd := &cobra.Command{
+		Use:     "errors",
+		Short:   "Asserts the declared errors state to NOT be true.",
+		Long:    `Asserts the declared errors state provided as an argument to not be true in the $KUBECONFIG cluster. Valid arguments are a YAML file, URL to a YAML file.`,
+		Example: errorsExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("one file argument is required")
+
+			}
+			return nil
+		},
+	}
+
+	errorsCmd.Flags().IntVar(&timeout, "timeout", 5, "The timeout to use as default for error evaluation.")
+	errorsCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace to use for test errors.")
+
+	return errorsCmd
+}

--- a/pkg/kuttlctl/cmd/root.go
+++ b/pkg/kuttlctl/cmd/root.go
@@ -25,6 +25,7 @@ and serves as an API aggregation layer.
 	}
 
 	cmd.AddCommand(newAssertCmd())
+	cmd.AddCommand(newErrorsCmd())
 	cmd.AddCommand(newTestCmd())
 	cmd.AddCommand(newVersionCmd())
 

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -528,7 +528,7 @@ func RuntimeObjectsFromPath(path, dir string) ([]runtime.Object, error) {
 	// it's a directory or file
 	paths, err := kfile.FromPath(filepath.Join(dir, path), "*.yaml")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to find YAML files in %s: %w", filepath.Join(dir, path), err)
 	}
 	apply, err := kfile.ToRuntimeObjects(paths)
 	if err != nil {


### PR DESCRIPTION
Errors command added which provides the ability to assert the absence of a manifest file on a cluster.  This is convenient when manually modifying a cluster and looking to assert that it is valid, or when creating an errors file.

when successful
```
go run cmd/kubectl-kuttl/main.go error --timeout 1 test.yaml
error assert is valid
```

when there is an assert failure
```
go run cmd/kubectl-kuttl/main.go errors -n temp test.yaml --timeout 2
resource matched of kind: /v1, Kind=Pod
Error: error asserts not valid
exit status 255
```

Fixes #125 
