### PR TITLE
Namespace flag allows tests with no ns creation

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -57,7 +57,8 @@ type TestSuite struct {
 	ReportFormat *report.Type
 	// Namespace defines the namespace to use for tests
 	// The value "" means to auto-generate tests namespaces, these namespaces will be created and removed for each test
-	// Any other value is the name of the namespace to use and it must be created prior to tests running
+	// Any other value is the name of the namespace to use.  This namespace will be created if it does not exist and will
+	// be removed it was created (unless --skipDelete is used).
 	Namespace string
 }
 

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -55,6 +55,10 @@ type TestSuite struct {
 
 	// ReportFormat determines test report format (JSON|XML|nil) nil == no report
 	ReportFormat *report.Type
+	// Namespace defines the namespace to use for tests
+	// The value "" means to auto-generate tests namespaces, these namespaces will be created and removed for each test
+	// Any other value is the name of the namespace to use and it must be created prior to tests running
+	Namespace string
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -163,6 +163,9 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 			}
 
 			if isSet(flags, "namespace") {
+				if strings.TrimSpace(namespace) == "" {
+					return errors.New(`setting namespace explicitly to "" or empty string is not supported`)
+				}
 				options.Namespace = namespace
 			}
 

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -53,6 +53,7 @@ func newTestCmd() *cobra.Command {
 	mockControllerFile := ""
 	timeout := 30
 	reportFormat := ""
+	namespace := ""
 
 	options := harness.TestSuite{}
 
@@ -161,6 +162,10 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 				options.ArtifactsDir = artifactsDir
 			}
 
+			if isSet(flags, "namespace") {
+				options.Namespace = namespace
+			}
+
 			if isSet(flags, "timeout") {
 				options.Timeout = timeout
 			}
@@ -214,6 +219,8 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 	testCmd.Flags().IntVar(&parallel, "parallel", 8, "The maximum number of tests to run at once.")
 	testCmd.Flags().IntVar(&timeout, "timeout", 30, "The timeout to use as default for TestSuite configuration.")
 	testCmd.Flags().StringVar(&reportFormat, "report", "", "Specify JSON|XML for report.  Report location determined by --artfacts-dir.")
+	testCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Namespace to use for tests. Provided namespaces must exist prior to running tests.")
+
 	// This cannot be a global flag because pkg/test/utils.RunTests calls flag.Parse which barfs on unknown top-level flags.
 	// Putting it here at least does not advertise it on a level where using it is impossible.
 	test.SetFlags(testCmd.Flags())

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -45,6 +45,7 @@ type Case struct {
 func (t *Case) DeleteNamespace(namespace string) error {
 	// if system defined namespace is "" we create and delete, otherwise don't
 	if t.Namespace != "" {
+		t.Logger.Log("Skipping deletion of user-supplied namespace:", namespace)
 		return nil
 	}
 
@@ -69,6 +70,7 @@ func (t *Case) DeleteNamespace(namespace string) error {
 func (t *Case) CreateNamespace(namespace string) error {
 	// if system defined namespace is "" we create and delete, otherwise don't
 	if t.Namespace != "" {
+		t.Logger.Log("Skipping creation of user-supplied namespace:", namespace)
 		return nil
 	}
 	t.Logger.Log("Creating namespace:", namespace)

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -208,7 +208,6 @@ func (t *Case) determineNamespace() (*namespace, error) {
 		Name:        t.Namespace,
 		AutoCreated: false,
 	}
-	//ns := t.Namespace
 	if t.Namespace == "" {
 		ns.Name = fmt.Sprintf("kudo-test-%s", petname.Generate(2, "-"))
 		ns.AutoCreated = true

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -13,6 +13,7 @@ import (
 	petname "github.com/dustinkirkland/golang-petname"
 	corev1 "k8s.io/api/core/v1"
 	eventsbeta1 "k8s.io/api/events/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,15 +42,19 @@ type Case struct {
 	Logger testutils.Logger
 }
 
+type namespace struct {
+	Name        string
+	AutoCreated bool
+}
+
 // DeleteNamespace deletes a namespace in Kubernetes after we are done using it.
-func (t *Case) DeleteNamespace(namespace string) error {
-	// if system defined namespace is "" we create and delete, otherwise don't
-	if t.Namespace != "" {
-		t.Logger.Log("Skipping deletion of user-supplied namespace:", namespace)
+func (t *Case) DeleteNamespace(ns *namespace) error {
+	if !ns.AutoCreated {
+		t.Logger.Log("Skipping deletion of user-supplied namespace:", ns.Name)
 		return nil
 	}
 
-	t.Logger.Log("Deleting namespace:", namespace)
+	t.Logger.Log("Deleting namespace:", ns.Name)
 
 	cl, err := t.Client(false)
 	if err != nil {
@@ -58,7 +63,7 @@ func (t *Case) DeleteNamespace(namespace string) error {
 
 	return cl.Delete(context.TODO(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name: ns.Name,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Namespace",
@@ -67,13 +72,12 @@ func (t *Case) DeleteNamespace(namespace string) error {
 }
 
 // CreateNamespace creates a namespace in Kubernetes to use for a test.
-func (t *Case) CreateNamespace(namespace string) error {
-	// if system defined namespace is "" we create and delete, otherwise don't
-	if t.Namespace != "" {
-		t.Logger.Log("Skipping creation of user-supplied namespace:", namespace)
+func (t *Case) CreateNamespace(ns *namespace) error {
+	if !ns.AutoCreated {
+		t.Logger.Log("Skipping creation of user-supplied namespace:", ns.Name)
 		return nil
 	}
-	t.Logger.Log("Creating namespace:", namespace)
+	t.Logger.Log("Creating namespace:", ns.Name)
 
 	cl, err := t.Client(false)
 	if err != nil {
@@ -82,12 +86,27 @@ func (t *Case) CreateNamespace(namespace string) error {
 
 	return cl.Create(context.TODO(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name: ns.Name,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Namespace",
 		},
 	})
+}
+
+// NamespaceExists gets namespace and returns true if it exists
+func (t *Case) NamespaceExists(namespace string) (bool, error) {
+
+	cl, err := t.Client(false)
+	if err != nil {
+		return false, err
+	}
+	ns := &corev1.Namespace{}
+	err = cl.Get(context.TODO(), client.ObjectKey{Name: namespace}, ns)
+	if err != nil && !errors.IsNotFound(err) {
+		return false, err
+	}
+	return ns.Name == namespace, nil
 }
 
 // byFirstTimestamp sorts a slice of events by first timestamp, using their involvedObject's name as a tie breaker.
@@ -136,9 +155,10 @@ func printEvents(events []eventsbeta1.Event, logger conversion.DebugLogger) {
 // Run runs a test case including all of its steps.
 func (t *Case) Run(test *testing.T, tc *report.Testcase) {
 	test.Parallel()
-	ns := t.Namespace
-	if t.Namespace == "" {
-		ns = fmt.Sprintf("kudo-test-%s", petname.Generate(2, "-"))
+
+	ns, err := t.determineNamespace()
+	if err != nil {
+		test.Fatal(err)
 	}
 
 	if err := t.CreateNamespace(ns); err != nil {
@@ -162,13 +182,13 @@ func (t *Case) Run(test *testing.T, tc *report.Testcase) {
 
 		if !t.SkipDelete {
 			defer func() {
-				if err := testStep.Clean(ns); err != nil {
+				if err := testStep.Clean(ns.Name); err != nil {
 					test.Error(err)
 				}
 			}()
 		}
 
-		if errs := testStep.Run(ns); len(errs) > 0 {
+		if errs := testStep.Run(ns.Name); len(errs) > 0 {
 			caseErr := fmt.Errorf("failed in step %s", testStep.String())
 			tc.Failure = report.NewFailure(caseErr.Error(), errs)
 
@@ -180,7 +200,26 @@ func (t *Case) Run(test *testing.T, tc *report.Testcase) {
 		}
 	}
 
-	t.CollectEvents(ns)
+	t.CollectEvents(ns.Name)
+}
+
+func (t *Case) determineNamespace() (*namespace, error) {
+	ns := &namespace{
+		Name:        t.Namespace,
+		AutoCreated: false,
+	}
+	//ns := t.Namespace
+	if t.Namespace == "" {
+		ns.Name = fmt.Sprintf("kudo-test-%s", petname.Generate(2, "-"))
+		ns.AutoCreated = true
+	} else {
+		exists, err := t.NamespaceExists(t.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		ns.AutoCreated = !exists
+	}
+	return ns, nil
 }
 
 // CollectTestStepFiles collects a map of test steps and their associated files

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -29,12 +29,12 @@ var testStepRegex = regexp.MustCompile(`^(\d+)-([^.]+)(.yaml)?$`)
 // Case contains all of the test steps and the Kubernetes client and other global configuration
 // for a test.
 type Case struct {
-	Steps      []*Step
-	Name       string
-	Dir        string
-	SkipDelete bool
-	Timeout    int
-	Namespace  string
+	Steps              []*Step
+	Name               string
+	Dir                string
+	SkipDelete         bool
+	Timeout            int
+	PreferredNamespace string
 
 	Client          func(forceNew bool) (client.Client, error)
 	DiscoveryClient func() (discovery.DiscoveryInterface, error)
@@ -205,14 +205,14 @@ func (t *Case) Run(test *testing.T, tc *report.Testcase) {
 
 func (t *Case) determineNamespace() (*namespace, error) {
 	ns := &namespace{
-		Name:        t.Namespace,
+		Name:        t.PreferredNamespace,
 		AutoCreated: false,
 	}
-	if t.Namespace == "" {
+	if t.PreferredNamespace == "" {
 		ns.Name = fmt.Sprintf("kudo-test-%s", petname.Generate(2, "-"))
 		ns.AutoCreated = true
 	} else {
-		exists, err := t.NamespaceExists(t.Namespace)
+		exists, err := t.NamespaceExists(t.PreferredNamespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -77,6 +77,7 @@ func (h *Harness) LoadTests(dir string) ([]*Case, error) {
 			Timeout:    timeout,
 			Steps:      []*Step{},
 			Name:       file.Name(),
+			Namespace:  h.TestSuite.Namespace,
 			Dir:        filepath.Join(dir, file.Name()),
 			SkipDelete: h.TestSuite.SkipDelete,
 		})

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -74,12 +74,12 @@ func (h *Harness) LoadTests(dir string) ([]*Case, error) {
 		}
 
 		tests = append(tests, &Case{
-			Timeout:    timeout,
-			Steps:      []*Step{},
-			Name:       file.Name(),
-			Namespace:  h.TestSuite.Namespace,
-			Dir:        filepath.Join(dir, file.Name()),
-			SkipDelete: h.TestSuite.SkipDelete,
+			Timeout:            timeout,
+			Steps:              []*Step{},
+			Name:               file.Name(),
+			PreferredNamespace: h.TestSuite.Namespace,
+			Dir:                filepath.Join(dir, file.Name()),
+			SkipDelete:         h.TestSuite.SkipDelete,
 		})
 	}
 


### PR DESCRIPTION
`test --namespace` support provided
rules:
1. The default namespace is ""
2. If default namespace, then tests will create their own namespaces for each tests (previous behavior)
3. if the namespace is provided then no namespaces will be created or deleted and the tests will run in that namespace.

Simple test run with "temp" ns
```
go run cmd/kubectl-kuttl/main.go test --start-control-plane=false ~/projects/playground/e2e/ -n temp
=== RUN   kuttl
    kuttl: harness.go:357: starting setup
    kuttl: harness.go:228: running tests using configured kubeconfig.
    kuttl: harness.go:303: running tests
    kuttl: harness.go:69: going to run test suite with timeout of 120 seconds for each step
=== RUN   kuttl/harness
=== RUN   kuttl/harness/pod
    kuttl/harness/pod: logger.go:42: 13:27:56 | pod | Ignoring pod.yaml as it does not match file name regexp: ^(\d+)-([^.]+)(.yaml)?$
=== PAUSE kuttl/harness/pod
=== CONT  kuttl/harness/pod
    kuttl/harness/pod: logger.go:42: 13:27:56 | pod/0-install | starting test step 0-install
    kuttl/harness/pod: logger.go:42: 13:27:56 | pod/0-install | Pod:temp/static-web created
    kuttl/harness/pod: logger.go:42: 13:27:58 | pod/0-install | test step completed 0-install
    kuttl/harness/pod: logger.go:42: 13:27:58 | pod | pod events from ns temp:
    kuttl/harness/pod: logger.go:42: 13:27:58 | pod | 2020-06-16 13:27:56 -0500 CDT	Normal	Scheduled	Successfully assigned temp/static-web to kind-control-plane
    kuttl/harness/pod: logger.go:42: 13:27:58 | pod | 2020-06-16 13:27:56 -0500 CDT	Normal	Pulling	Pulling image "nginx"
    kuttl/harness/pod: logger.go:42: 13:27:58 | pod | 2020-06-16 13:27:57 -0500 CDT	Normal	Pulled	Successfully pulled image "nginx"
    kuttl/harness/pod: logger.go:42: 13:27:58 | pod | 2020-06-16 13:27:57 -0500 CDT	Normal	Created	Created container web
    kuttl/harness/pod: logger.go:42: 13:27:58 | pod | 2020-06-16 13:27:57 -0500 CDT	Normal	Started	Started container web
    kuttl: harness.go:342: run tests finished
--- PASS: kuttl (3.00s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/pod (2.38s)
PASS

```

Signed-off-by: Ken Sipe <kensipe@gmail.com>
Fixes #6
