### PR TITLE
Enhanced In Cluster Detection which Fixes Command Runs Out of Cluster

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -227,7 +227,8 @@ func (h *Harness) Config() (*rest.Config, error) {
 	} else {
 		h.T.Log("running tests using configured kubeconfig.")
 		h.config, err = config.GetConfig()
-		if err == nil {
+		inK, _ := testutils.InClusterConfig()
+		if err == nil && inK {
 			return h.config, nil
 		}
 	}
@@ -236,6 +237,7 @@ func (h *Harness) Config() (*rest.Config, error) {
 		return h.config, err
 	}
 
+	// The creation of the "kubeconfig" is necessary for out of cluster execution of kubectl
 	f, err := os.Create("kubeconfig")
 	if err != nil {
 		return h.config, err

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -227,8 +227,8 @@ func (h *Harness) Config() (*rest.Config, error) {
 	} else {
 		h.T.Log("running tests using configured kubeconfig.")
 		h.config, err = config.GetConfig()
-		inK, _ := testutils.InClusterConfig()
-		if err == nil && inK {
+		inCluster, _ := testutils.InClusterConfig()
+		if err == nil && inCluster {
 			return h.config, nil
 		}
 	}

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1158,3 +1158,15 @@ func GetDiscoveryClient(mgr manager.Manager) (*discovery.DiscoveryClient, error)
 
 	return dc, nil
 }
+
+// InClusterConfig returns true if in cluster, false if not
+func InClusterConfig() (bool, error) {
+	_, err := rest.InClusterConfig()
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, rest.ErrNotInCluster) {
+		return false, nil
+	}
+	return false, err
+}


### PR DESCRIPTION
PR https://github.com/kudobuilder/kuttl/pull/133 made things work for in-cluster runs of kuttl, however it broke out of cluster runs of commands.  This fixes that with a check for in-cluster.


Signed-off-by: Ken Sipe <kensipe@gmail.com>


