### PR TITLE
Pod Log Collector for Assert Failures

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -148,7 +148,7 @@ type TestCollector struct {
 }
 
 func (tc *TestCollector) Command() *Command {
-	c := fmt.Sprintf("kubectl logs %s", tc.Pod)
+	c := fmt.Sprintf("kubectl logs --prefix %s", tc.Pod)
 	ns := tc.Namespace
 	if tc.Namespace == "" {
 		ns = "$NAMESPACE"

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -172,5 +172,23 @@ func (tc *TestCollector) Command() *Command {
 	}
 }
 
+func (tc *TestCollector) String() string {
+	named := false
+	var b strings.Builder
+	b.WriteString("[")
+	if len(tc.Pod) > 0 {
+		named = true
+		fmt.Fprintf(&b, "pod==%s", tc.Pod)
+	}
+	if len(tc.Selector) > 0 {
+		if named {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "label: %s", tc.Selector)
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
 // DefaultKINDContext defines the default kind context to use.
 const DefaultKINDContext = "kind"

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -137,15 +137,16 @@ type Command struct {
 	SkipLogOutput bool `json:"skipLogOutput"`
 }
 
-// TestCollector are post assert / error commands that allow for the collection of information sent to the test log
+// TestCollector are post assert / error commands that allow for the collection of information sent to the test log.
+// At least one of `pod` or `selector` is required.
 type TestCollector struct {
 	// The pod name to access logs.
 	Pod string `json:"pod"`
-	// namespace to use.
+	// namespace to use. The current test namespace will be used by default.
 	Namespace string `json:"namespace"`
-	// Container in pod to get logs from
+	// Container in pod to get logs from else --all-containers is used.
 	Container string `json:"container"`
-	// Selector is a label query to select pod
+	// Selector is a label query to select pod.
 	Selector string `json:"selector"`
 }
 
@@ -163,8 +164,10 @@ func (tc *TestCollector) Command() *Command {
 		ns = "$NAMESPACE"
 	}
 	fmt.Fprintf(&b, " -n %s", ns)
-	if len(tc.Container) != 0 {
+	if len(tc.Container) > 0 {
 		fmt.Fprintf(&b, " -c %s", tc.Container)
+	} else {
+		b.WriteString(" --all-containers")
 	}
 	return &Command{
 		Command:       b.String(),

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -410,13 +410,14 @@ func (s *Step) Run(namespace string) []error {
 	}
 	// test failure processing
 	s.Logger.Log("test step failed", s.String())
-	for _, collector := range s.Step.AssertionCollectors {
+	for _, collector := range s.Assert.Collectors {
+		s.Logger.Log("collecting log output for %s", collector)
 		_, err := testutils.RunCommand(context.TODO(), namespace, *collector.Command(), s.Dir, s.Logger, s.Logger, s.Logger, s.Timeout)
 		if err != nil {
 			s.Logger.Log("post assert collector failure: %s", err)
 		}
 	}
-	if len(s.Step.AssertionCollectors) > 0 {
+	if len(s.Assert.Collectors) > 0 {
 		s.Logger.Flush()
 	}
 	return testErrors

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -403,12 +403,22 @@ func (s *Step) Run(namespace string) []error {
 		time.Sleep(time.Second)
 	}
 
+	// all is good
 	if len(testErrors) == 0 {
 		s.Logger.Log("test step completed", s.String())
-	} else {
-		s.Logger.Log("test step failed", s.String())
+		return testErrors
 	}
-
+	// test failure processing
+	s.Logger.Log("test step failed", s.String())
+	for _, collector := range s.Step.AssertionCollectors {
+		_, err := testutils.RunCommand(context.TODO(), namespace, *collector.Command(), s.Dir, s.Logger, s.Logger, s.Logger, s.Timeout)
+		if err != nil {
+			s.Logger.Log("post assert collector failure: %s", err)
+		}
+	}
+	if len(s.Step.AssertionCollectors) > 0 {
+		s.Logger.Flush()
+	}
 	return testErrors
 }
 

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -411,7 +411,7 @@ func (s *Step) Run(namespace string) []error {
 	// test failure processing
 	s.Logger.Log("test step failed", s.String())
 	for _, collector := range s.Assert.Collectors {
-		s.Logger.Log("collecting log output for %s", collector)
+		s.Logger.Logf("collecting log output for %s", collector.String())
 		_, err := testutils.RunCommand(context.TODO(), namespace, *collector.Command(), s.Dir, s.Logger, s.Logger, s.Logger, s.Timeout)
 		if err != nil {
 			s.Logger.Log("post assert collector failure: %s", err)


### PR DESCRIPTION
Provides Pod Log output on Assert or Error failure.
This is configured in the `TestAssert` Object and can be done with a pod name or a label selector.

For instance adding the following to an assert file:
```
apiVersion: kuttl.dev/v1beta1
kind: TestAssert
collectors:
  - selector: app=nginx
```

or this:
```
apiVersion: kuttl.dev/v1beta1
kind: TestAssert
collectors:
  - pod: static-web     
```

A namespace can be provided or it will default to the current test namespace.

The "collectors" is a list and multiple collectors can be provided.  They provide an output only if there is an assertion error and just prior to the output of the errors.  An example looks like:

```
    kuttl/harness/pod: logger.go:42: 22:50:15 | pod/0-install | collecting log output for [label: app=nginx]
    kuttl/harness/pod: logger.go:42: 22:50:15 | pod/0-install | running command: [kubectl logs --prefix -l app=nginx -n kudo-test-skilled-caribou]
    kuttl/harness/pod: logger.go:42: 22:50:15 | pod/0-install | [pod/static-web/web] /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
    kuttl/harness/pod: logger.go:42: 22:50:15 | pod/0-install | [pod/static-web/web] /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
    kuttl/harness/pod: logger.go:42: 22:50:15 | pod/0-install | [pod/static-web/web] /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
    kuttl/harness/pod: logger.go:42: 22:50:15 | pod/0-install | [pod/static-web/web] 10-listen-on-ipv6-by-default.sh: Getting the checksum of /etc/nginx/conf.d/default.conf
    kuttl/harness/pod: logger.go:42: 22:50:15 | pod/0-install | [pod/static-web/web] 10-listen-on-ipv6-by-default.sh: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
    kuttl/harness/pod: logger.go:42: 22:50:15 | pod/0-install | [pod/static-web/web] /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
    kuttl/harness/pod: logger.go:42: 22:50:15 | pod/0-install | [pod/static-web/web] /docker-entrypoint.sh: Configuration complete; ready for start up

```

Fixes #16 
