### PR TITLE
Kind Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ reports/
 kuttl.yaml
 kuttl-report.json
 kuttl-report.xml
+kind-logs-*/
 
 
 ### mac

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ cli:
 cli-clean:
 	rm -f bin/${CLI}
 
+.PHONY: clean
+clean: cli-clean
+	rm -rf kind-logs-*
+
 .PHONY: docker
 # build docker image
 docker:

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -239,9 +239,9 @@ func (h *Harness) Config() (*rest.Config, error) {
 
 	// if not the mocked control plane
 	if !h.TestSuite.StartControlPlane {
-		// newly started cluster aren't ready until default service account is ready
+		// newly started clusters aren't ready until default service account is ready
 		// fixes: error looking up service account <namespace>/default: serviceaccount "default" not found
-		// no need for this with "inCluster" as we are self evident of it's existence.
+		// we avoid this with "inCluster" as the cluster must be already be up since we're running on it
 		err = testutils.WaitForSA(h.config, "default", "default")
 		if err != nil {
 			return h.config, err

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -237,6 +237,17 @@ func (h *Harness) Config() (*rest.Config, error) {
 		return h.config, err
 	}
 
+	// if not the mocked control plane
+	if !h.TestSuite.StartControlPlane {
+		// newly started cluster aren't ready until default service account is ready
+		// fixes: error looking up service account <namespace>/default: serviceaccount "default" not found
+		// no need for this with "inCluster" as we are self evident of it's existence.
+		err = testutils.WaitForSA(h.config, "default", "default")
+		if err != nil {
+			return h.config, err
+		}
+	}
+
 	// The creation of the "kubeconfig" is necessary for out of cluster execution of kubectl
 	f, err := os.Create("kubeconfig")
 	if err != nil {

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -843,6 +843,34 @@ func WaitForDelete(c *RetryClient, objs []runtime.Object) error {
 	})
 }
 
+// WaitForSA waits for a service account to be present
+func WaitForSA(config *rest.Config, name, namespace string) error {
+
+	c, err := NewRetryClient(config, client.Options{
+		Scheme: Scheme(),
+	})
+	if err != nil {
+		return err
+	}
+
+	obj := &corev1.ServiceAccount{}
+
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+	return wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (done bool, err error) {
+		err = c.Get(context.TODO(), key, obj)
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
 // WaitForCRDs waits for the provided CRD types to be available in the Kubernetes API.
 func WaitForCRDs(dClient discovery.DiscoveryInterface, crds []runtime.Object) error {
 	waitingFor := []schema.GroupVersionKind{}


### PR DESCRIPTION
This PR provides some clean up around working with kind server

1. ignore the kind generated log dirs if they exist
2. provide a make target to clean the log dirs
3. provide better setup as we kept getting failures detailed below because the cluster wasn't ready.

There was a common failure in particular with a built-in kind server creation where kind was still materializing which resulted in:
```
 kuttl/harness/pod: case.go:161: pods "static-web" is forbidden: error looking up service account kudo-test-national-mammal/default: serviceaccount "default" not found
``` 
Added a `WaitForSA` when working with any cluster, which is NOT applied for the following:
1. in-cluster detection (sa would have to be present)
2. running the mock control plane where it will never be present.