### PR TITLE
removing report type from exteralized types

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -3,8 +3,6 @@ package v1beta1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kudobuilder/kuttl/pkg/report"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -54,7 +52,8 @@ type TestSuite struct {
 	Commands []Command `json:"commands"`
 
 	// ReportFormat determines test report format (JSON|XML|nil) nil == no report
-	ReportFormat *report.Type
+	// maps to report.Type, however we don't want generated.deepcopy to have reference to it.
+	ReportFormat string
 	// Namespace defines the namespace to use for tests
 	// The value "" means to auto-generate tests namespaces, these namespaces will be created and removed for each test
 	// Any other value is the name of the namespace to use.  This namespace will be created if it does not exist and will

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -231,14 +231,14 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 	return testCmd
 }
 
-func reportType(ftype report.Type) *report.Type {
+func reportType(ftype report.Type) string {
 	switch ftype {
 	case report.JSON:
 		fallthrough
 	case report.XML:
-		return &ftype
+		return string(ftype)
 	default:
-		return nil
+		return ""
 	}
 }
 

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -485,10 +485,10 @@ func (h *Harness) explicitPath() string {
 // Report defines the report phase of the kuttl tests.  If report format is nil it is skipped.
 // otherwise it will provide a json or xml format report of tests in a junit format.
 func (h *Harness) Report() {
-	if h.TestSuite.ReportFormat == nil {
+	if len(h.TestSuite.ReportFormat) == 0 {
 		return
 	}
-	if err := h.report.Report(h.TestSuite.ArtifactsDir, *h.TestSuite.ReportFormat); err != nil {
+	if err := h.report.Report(h.TestSuite.ArtifactsDir, report.Type(h.TestSuite.ReportFormat)); err != nil {
 		h.fatal(fmt.Errorf("fatal error writing report: %v", err))
 	}
 }


### PR DESCRIPTION
The generated files were out of date... in looking at fixing them, there was a report.Type imported in the generated.deepcopy.  We don't want this.   Updated to remove this concern.  The result is no change to the generated.deepcopy... yay!

Signed-off-by: Ken Sipe <kensipe@gmail.com>
