### PR TITLE
Configurable Report Name from API

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -57,6 +57,9 @@ type TestSuite struct {
 	// ReportFormat determines test report format (JSON|XML|nil) nil == no report
 	// maps to report.Type, however we don't want generated.deepcopy to have reference to it.
 	ReportFormat string
+
+	// ReportName defines the name of report to create.  It defaults to "kuttl-test" and is not used unless ReportFormat is defined.
+	ReportName string
 	// Namespace defines the namespace to use for tests
 	// The value "" means to auto-generate tests namespaces, these namespaces will be created and removed for each test
 	// Any other value is the name of the namespace to use.  This namespace will be created if it does not exist and will

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -107,7 +107,7 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 			}
 
 			// Override configuration file options with any command line flags if they are set.
-
+			options.ReportName = "kuttl-test"
 			if isSet(flags, "crd-dir") {
 				options.CRDDir = crdDir
 			}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -3,6 +3,7 @@ package report
 import (
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"time"
@@ -208,7 +209,7 @@ func latestEnd(start time.Time, testcases []*Testcase) time.Time {
 }
 
 // Report prints a report for TestSuites to the directory.  ftype == json | xml
-func (ts *Testsuites) Report(dir string, ftype Type) error {
+func (ts *Testsuites) Report(dir, name string, ftype Type) error {
 	ts.Close()
 	// don't print if there is nothing
 	if len(ts.Testsuite) == 0 {
@@ -216,11 +217,11 @@ func (ts *Testsuites) Report(dir string, ftype Type) error {
 	}
 	switch ftype {
 	case XML:
-		return writeXMLReport(dir, ts)
+		return writeXMLReport(dir, name, ts)
 	case JSON:
 		fallthrough
 	default:
-		return writeJSONReport(dir, ts)
+		return writeJSONReport(dir, name, ts)
 	}
 }
 
@@ -231,8 +232,9 @@ func (ts *Testsuites) NewSuite(name string) *Testsuite {
 	return suite
 }
 
-func writeXMLReport(dir string, ts *Testsuites) error {
-	file := filepath.Join(dir, "kuttl-report.xml")
+func writeXMLReport(dir, name string, ts *Testsuites) error {
+
+	file := filepath.Join(dir, fmt.Sprintf("%s.xml", name))
 	xDoc, err := xml.MarshalIndent(ts, " ", "  ")
 	if err != nil {
 		return err
@@ -241,8 +243,8 @@ func writeXMLReport(dir string, ts *Testsuites) error {
 	return ioutil.WriteFile(file, []byte(xmlStr), 0644)
 }
 
-func writeJSONReport(dir string, ts *Testsuites) error {
-	file := filepath.Join(dir, "kuttl-report.json")
+func writeJSONReport(dir, name string, ts *Testsuites) error {
+	file := filepath.Join(dir, fmt.Sprintf("%s.json", name))
 	jDoc, err := json.MarshalIndent(ts, " ", "  ")
 	if err != nil {
 		return err

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -512,7 +512,7 @@ func (h *Harness) Report() {
 	if len(h.TestSuite.ReportFormat) == 0 {
 		return
 	}
-	if err := h.report.Report(h.TestSuite.ArtifactsDir, report.Type(h.TestSuite.ReportFormat)); err != nil {
+	if err := h.report.Report(h.TestSuite.ArtifactsDir, h.TestSuite.ReportName, report.Type(h.TestSuite.ReportFormat)); err != nil {
 		h.fatal(fmt.Errorf("fatal error writing report: %v", err))
 	}
 }


### PR DESCRIPTION
We can debate if we should extend this feature to the CLI... there hasn't been any requests for it.  It will be easy to do if we get a requests. 

This PR is to enable 3rd parties integrating kuttl at an API level to be able to control the report name output.  It would be odd for `kudo test` to output a kuttl-test.xml file.   

This is the minimum changes to enable API integrators to control the report name.

Signed-off-by: Ken Sipe <kensipe@gmail.com>
