### PR TITLE
Fixed Seg Fault and Added Regression Tests

### DIFF
--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -410,6 +410,9 @@ func (s *Step) Run(namespace string) []error {
 	}
 	// test failure processing
 	s.Logger.Log("test step failed", s.String())
+	if s.Assert == nil {
+		return testErrors
+	}
 	for _, collector := range s.Assert.Collectors {
 		s.Logger.Logf("collecting log output for %s", collector.String())
 		_, err := testutils.RunCommand(context.TODO(), namespace, *collector.Command(), s.Dir, s.Logger, s.Logger, s.Logger, s.Timeout)


### PR DESCRIPTION
The new test failure collectors are configured with the Step.Assert.  There is no guarantee that the `Assert` object exists... in a configuration without a `TestAssert` object defined, this object is nil.  Nil check added.  An integration test has been added which would have caught this failure.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #154 
