### PR TITLE
Reports: write elapsed time in seconds

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -140,7 +140,7 @@ func (ts *Testsuite) AddTestcase(testcase *Testcase) {
 	// this is needed to calc elapse time of testsuite in a async work
 	testcase.end = time.Now()
 	elapsed := time.Since(testcase.start)
-	testcase.Time = elapsed.String()
+	testcase.Time = fmt.Sprintf("%.3f", elapsed.Seconds())
 	testcase.Classname = filepath.Base(ts.Name)
 
 	ts.Testcase = append(ts.Testcase, testcase)
@@ -185,12 +185,12 @@ func (ts *Testsuites) AddProperty(property Property) {
 // Close closes the report and does all end stat calculations
 func (ts *Testsuites) Close() {
 	elapsed := time.Since(ts.start)
-	ts.Time = elapsed.String()
+	ts.Time = fmt.Sprintf("%.3f", elapsed.Seconds())
 
 	// async work makes this necessary (stats for each testsuite)
 	for _, testsuite := range ts.Testsuite {
 		elapsed = latestEnd(testsuite.start, testsuite.Testcase).Sub(testsuite.start)
-		testsuite.Time = elapsed.String()
+		testsuite.Time = fmt.Sprintf("%.3f", elapsed.Seconds())
 
 		ts.Tests += testsuite.Tests
 		ts.Failures += testsuite.Failures


### PR DESCRIPTION
Signed-off-by: Alex Lembiewski <alembiyeuski.c@d2iq.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

This PR changes the output format for all `time` attributes to adhere to [XSD schema](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd#L130).

The current format cannot be parsed properly by Teamcity (test durations are reported as `< 1 ms`):

<img width="982" alt="Screen Shot 2020-07-07 at 09 41 40" src="https://user-images.githubusercontent.com/47157503/86774240-07973e80-c05f-11ea-9d97-6f06855d2c1a.png">


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

