### PR TITLE
Add report commands to execute commands after tests are finished

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -53,6 +53,9 @@ type TestSuite struct {
 	// Commands to run prior to running the tests.
 	Commands []Command `json:"commands"`
 
+	// Commands to run in the reporting phase after finishing the tests but before shutdown of the cluster.
+	ReportCommands []Command `json:"postCommands"`
+
 	// ReportFormat determines test report format (JSON|XML|nil) nil == no report
 	ReportFormat *report.Type
 	// Namespace defines the namespace to use for tests

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -54,7 +54,7 @@ type TestSuite struct {
 	Commands []Command `json:"commands"`
 
 	// Commands to run in the reporting phase after finishing the tests but before shutdown of the cluster.
-	ReportCommands []Command `json:"postCommands"`
+	ReportCommands []Command `json:"reportCommands"`
 
 	// ReportFormat determines test report format (JSON|XML|nil) nil == no report
 	ReportFormat *report.Type

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -340,6 +340,16 @@ func (h *Harness) RunTests() {
 	})
 
 	h.T.Log("run tests finished")
+
+	logger := h.GetLogger()
+	logger.Log("running %n report commands", len(h.TestSuite.ReportCommands))
+	if len(h.TestSuite.ReportCommands) != 0 {
+		testutils.ClearBackgroundFlags(h.GetLogger(), h.TestSuite.ReportCommands, "report")
+		if _, errs := testutils.RunCommands(h.GetLogger(), "default", h.TestSuite.ReportCommands, "", h.TestSuite.Timeout); len(errs) != 0 {
+			h.fatal(fmt.Errorf("fatal error running post commands: %v", errs))
+		}
+	}
+
 }
 
 // Run the test harness - start the control plane and then run the tests.
@@ -483,13 +493,6 @@ func (h *Harness) explicitPath() string {
 // Report defines the report phase of the kuttl tests.  If report format is nil it is skipped.
 // otherwise it will provide a json or xml format report of tests in a junit format.
 func (h *Harness) Report() {
-	if len(h.TestSuite.ReportCommands) != 0 {
-		testutils.ClearBackgroundFlags(h.GetLogger(), h.TestSuite.ReportCommands, "report")
-		if _, errs := testutils.RunCommands(h.GetLogger(), "default", h.TestSuite.ReportCommands, "", h.TestSuite.Timeout); errs != nil {
-			h.fatal(fmt.Errorf("fatal error running post commands: %v", errs))
-		}
-	}
-
 	if h.TestSuite.ReportFormat == nil {
 		return
 	}

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -483,6 +483,13 @@ func (h *Harness) explicitPath() string {
 // Report defines the report phase of the kuttl tests.  If report format is nil it is skipped.
 // otherwise it will provide a json or xml format report of tests in a junit format.
 func (h *Harness) Report() {
+	if len(h.TestSuite.ReportCommands) != 0 {
+		testutils.ClearBackgroundFlags(h.GetLogger(), h.TestSuite.ReportCommands, "report")
+		if _, errs := testutils.RunCommands(h.GetLogger(), "default", h.TestSuite.ReportCommands, "", h.TestSuite.Timeout); errs != nil {
+			h.fatal(fmt.Errorf("fatal error running post commands: %v", errs))
+		}
+	}
+
 	if h.TestSuite.ReportFormat == nil {
 		return
 	}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -376,12 +376,7 @@ func (s *Step) Run(namespace string) []error {
 	testErrors := []error{}
 
 	if s.Step != nil {
-		for _, command := range s.Step.Commands {
-			if command.Background {
-				s.Logger.Log("background commands are not allowed for steps and will be run in foreground")
-				command.Background = false
-			}
-		}
+		testutils.ClearBackgroundFlags(s.Logger, s.Step.Commands, "steps")
 		if _, errors := testutils.RunCommands(s.Logger, namespace, s.Step.Commands, s.Dir, s.Timeout); errors != nil {
 			testErrors = append(testErrors, errors...)
 		}

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1067,8 +1067,6 @@ func RunCommands(logger Logger, namespace string, commands []harness.Command, wo
 	}
 
 	for _, cmd := range commands {
-		logger.Logf("running command: %q", cmd.Command)
-
 		bg, err := RunCommand(context.Background(), namespace, cmd, workdir, logger, logger, logger, timeout)
 		if err != nil {
 			errs = append(errs, err)

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1045,6 +1045,16 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 	return nil, err
 }
 
+// ClearBackgroundFlags sets the 'Background' flag of the passed in commands to false and logs a message
+func ClearBackgroundFlags(logger Logger, commands []harness.Command, phaseName string) {
+	for _, command := range commands {
+		if command.Background {
+			logger.Logf("background commands are not allowed for %s and %s will be run in foreground", phaseName, command.Command)
+			command.Background = false
+		}
+	}
+}
+
 // RunCommands runs a set of commands, returning any errors.
 // If `command` is set, then `command` will be the command that is invoked (if a command specifies it already, it will not be prepended again).
 // commands running in the background are returned


### PR DESCRIPTION
Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>

**What this PR does / why we need it**:
- Add report commands which are executed after the test steps are done, but before the cluster is stopped.

Fixes #
