### PR TITLE
Releasing Additional Platforms

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,8 @@ builds:
       - 386
       - amd64
       - arm
+      - ppc64le
+      - s390x
 archives:
   - id: kubectl-kuttl-tarball
     builds:


### PR DESCRIPTION
KUTTL is aligned with Operator SDK Score Testing which supports additional platforms.  This PR adds the missing platforms for alignment.

At this time we are not adding any additional support promises.  This is consistent to our existing arm platform release.

Signed-off-by: Ken Sipe <kensipe@gmail.com>
