### PR TITLE
update for goreleaser based on deprecation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,7 @@ archives:
     format: binary
 brews:
   - name: kuttl-cli
-    github:
+    tap:
       owner: kudobuilder
       name: homebrew-tap
     commit_author:


### PR DESCRIPTION
update for goreleaser based on deprecation

https://goreleaser.com/deprecations/#brewsgithub

Signed-off-by: Ken Sipe <kensipe@gmail.com>
