### PR TITLE
Existing Kind Cluster should not be killed by kuttl

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -121,8 +122,12 @@ func (h *Harness) RunKIND() (*rest.Config, error) {
 		h.kind = &kind
 
 		if h.kind.IsRunning() {
-			h.T.Logf("KIND is already running, using existing cluster")
-			return clientcmd.BuildConfigFromFlags("", h.kubeconfigPath())
+			// we don't take over an existing kind cluster for --start-kind
+			// which means we do not stop that cluster.  User will either need to switch to existing cluster or stop it.
+			h.kind = nil
+			msg := "KIND is already running, unable to start"
+			h.T.Log(msg)
+			return nil, errors.New(msg)
 		}
 
 		kindCfg := &kindConfig.Cluster{}


### PR DESCRIPTION
PR #80 introduced an issue, where if `--start-kind` would "take over" an already running kind cluster.  First, this seems like a mistake.  If a user specifies to start a cluster and kuttl can't start one because one exists, kuttl can't assume that the existing cluster is ok.   Second, the "take over" was never complete, acquiring a KubeClient fails under this scenario, however the handle to the existing kind cluster is maintained and destroyed during the clean up phase.  Compounding the issue.

It seems best to only start Kind if we can... and force user to be explicit that they want to use an existing cluster.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #181 
