### PR TITLE
Better Command Error Handling

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -466,11 +466,11 @@ func (h *Harness) Setup() {
 			h.fatal(fmt.Errorf("fatal error installing manifests: %v", err))
 		}
 	}
-	bgs, errs := testutils.RunCommands(h.GetLogger(), "default", h.TestSuite.Commands, "", h.TestSuite.Timeout)
+	bgs, err := testutils.RunCommands(h.GetLogger(), "default", h.TestSuite.Commands, "", h.TestSuite.Timeout)
 	// assign any background processes first for cleanup in case of any errors
 	h.bgProcesses = append(h.bgProcesses, bgs...)
-	if len(errs) > 0 {
-		h.fatal(fmt.Errorf("fatal error running commands: %v", errs))
+	if err != nil {
+		h.fatal(fmt.Errorf("fatal error running commands: %v", err))
 	}
 }
 

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -382,8 +382,8 @@ func (s *Step) Run(namespace string) []error {
 				command.Background = false
 			}
 		}
-		if _, errors := testutils.RunCommands(s.Logger, namespace, s.Step.Commands, s.Dir, s.Timeout); errors != nil {
-			testErrors = append(testErrors, errors...)
+		if _, err := testutils.RunCommands(s.Logger, namespace, s.Step.Commands, s.Dir, s.Timeout); err != nil {
+			testErrors = append(testErrors, err)
 		}
 	}
 

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1075,7 +1075,7 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 }
 
 // RunCommands runs a set of commands, returning any errors.
-// If `command` is set, then `command` will be the command that is invoked (if a command specifies it already, it will not be prepended again).
+// If any (non-background) command fails, the following commands are skipped
 // commands running in the background are returned
 func RunCommands(logger Logger, namespace string, commands []harness.Command, workdir string, timeout int) ([]*exec.Cmd, error) {
 	bgs := []*exec.Cmd{}


### PR DESCRIPTION
Please read issue #170 for more details.
The error handling of commands from a UX standpoint was confusing.   Now the first command to fail (that isn't registered to be ignored) will stop all other commands and will return that error.  It also logs the number of skipped commands.

The result of running the example provided in the issue is:

```
=== RUN   kuttl
    kuttl: harness.go:434: starting setup
    kuttl: harness.go:246: running tests using configured kubeconfig.
    kuttl: logger.go:42: 13:23:16 |  | running command: [sleep 3]
    kuttl: logger.go:42: 13:23:18 |  | command failure, skipping 1 additional commands
    kuttl: harness.go:479: cleaning up
    kuttl: harness.go:531: removing temp folder: ""
    kuttl: harness.go:555: fatal error running commands: command "sleep 3" exceeded 2 sec timeout
--- FAIL: kuttl (2.78s)
FAIL
```

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #170 
