### PR TITLE
Timeouts for Create and Updates

### DIFF
--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -192,10 +192,10 @@ func (t *Case) Run(test *testing.T, tc *report.Testcase) {
 			caseErr := fmt.Errorf("failed in step %s", testStep.String())
 			tc.Failure = report.NewFailure(caseErr.Error(), errs)
 
+			test.Error(caseErr)
 			for _, err := range errs {
 				test.Error(err)
 			}
-			test.Error(caseErr)
 			break
 		}
 	}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -174,8 +174,15 @@ func (s *Step) Create(namespace string) []error {
 			errors = append(errors, err)
 			continue
 		}
+		ctx := context.Background()
+		if s.Timeout > 0 {
+			var cancel context.CancelFunc
+			//TODO (kensipe): fix time s.Timeout
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(2)*time.Second)
+			defer cancel()
+		}
 
-		if updated, err := testutils.CreateOrUpdate(context.TODO(), cl, obj, true); err != nil {
+		if updated, err := testutils.CreateOrUpdate(ctx, cl, obj, true); err != nil {
 			errors = append(errors, err)
 		} else {
 			action := "created"

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -177,8 +177,7 @@ func (s *Step) Create(namespace string) []error {
 		ctx := context.Background()
 		if s.Timeout > 0 {
 			var cancel context.CancelFunc
-			//TODO (kensipe): fix time s.Timeout
-			ctx, cancel = context.WithTimeout(ctx, time.Duration(2)*time.Second)
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(s.Timeout)*time.Second)
 			defer cancel()
 		}
 


### PR DESCRIPTION
We have timeouts for asserts and commands... but no timeouts for create / update.
Bug #62 has more details.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #62 
