### PR TITLE
Suppress Events with Flag

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -62,6 +62,8 @@ type TestSuite struct {
 	// Any other value is the name of the namespace to use.  This namespace will be created if it does not exist and will
 	// be removed it was created (unless --skipDelete is used).
 	Namespace string
+	// Suppress is used to suppress logs
+	Suppress []string
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -37,6 +37,7 @@ var (
 )
 
 // newTestCmd creates the test command for the CLI
+// nolint:gocyclo
 func newTestCmd() *cobra.Command {
 	configPath := ""
 	crdDir := ""
@@ -54,6 +55,7 @@ func newTestCmd() *cobra.Command {
 	timeout := 30
 	reportFormat := ""
 	namespace := ""
+	suppress := []string{}
 
 	options := harness.TestSuite{}
 
@@ -169,6 +171,12 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 				options.Namespace = namespace
 			}
 
+			if isSet(flags, "suppress-log") {
+				for _, s := range suppress {
+					options.Suppress = append(options.Suppress, strings.ToLower(s))
+				}
+			}
+
 			if isSet(flags, "timeout") {
 				options.Timeout = timeout
 			}
@@ -223,7 +231,7 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 	testCmd.Flags().IntVar(&timeout, "timeout", 30, "The timeout to use as default for TestSuite configuration.")
 	testCmd.Flags().StringVar(&reportFormat, "report", "", "Specify JSON|XML for report.  Report location determined by --artifacts-dir.")
 	testCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Namespace to use for tests. Provided namespaces must exist prior to running tests.")
-
+	testCmd.Flags().StringSliceVar(&suppress, "suppress-log", []string{}, "Suppress logging for these kinds of logs (events).")
 	// This cannot be a global flag because pkg/test/utils.RunTests calls flag.Parse which barfs on unknown top-level flags.
 	// Putting it here at least does not advertise it on a level where using it is impossible.
 	test.SetFlags(testCmd.Flags())

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -204,7 +204,7 @@ func (t *Case) Run(test *testing.T, tc *report.Testcase) {
 	}
 
 	if funk.Contains(t.Suppress, "events") {
-		t.Logger.Logf("skipping event logging")
+		t.Logger.Logf("skipping kubernetes event logging")
 	} else {
 		t.CollectEvents(ns.Name)
 	}

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	petname "github.com/dustinkirkland/golang-petname"
+	"github.com/thoas/go-funk"
 	corev1 "k8s.io/api/core/v1"
 	eventsbeta1 "k8s.io/api/events/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -40,6 +41,8 @@ type Case struct {
 	DiscoveryClient func() (discovery.DiscoveryInterface, error)
 
 	Logger testutils.Logger
+	// Suppress is used to suppress logs
+	Suppress []string
 }
 
 type namespace struct {
@@ -200,7 +203,11 @@ func (t *Case) Run(test *testing.T, tc *report.Testcase) {
 		}
 	}
 
-	t.CollectEvents(ns.Name)
+	if funk.Contains(t.Suppress, "events") {
+		t.Logger.Logf("skipping event logging")
+	} else {
+		t.CollectEvents(ns.Name)
+	}
 }
 
 func (t *Case) determineNamespace() (*namespace, error) {

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -84,6 +84,7 @@ func (h *Harness) LoadTests(dir string) ([]*Case, error) {
 			PreferredNamespace: h.TestSuite.Namespace,
 			Dir:                filepath.Join(dir, file.Name()),
 			SkipDelete:         h.TestSuite.SkipDelete,
+			Suppress:           h.TestSuite.Suppress,
 		})
 	}
 


### PR DESCRIPTION
Details in the Issue reported below.  This starts the ability to suppress output with the ability to support events.
`--suppress-log=events` will suppress events.

Thinking the following:
1. there is likely more things to suppress (commands, etc)
2. there might be value in having a "context" passed throughout the tests... where things like this can be added to the context.  That requires more thought.

This was a user request and looks to solve that issue for the next release.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #156 
