### PR TITLE
Adding verify generate to circle lint task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
       - run: make lint
+      - run: ./hack/verify-generate.sh
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ cli-install:  ## Installs kubectl-kuttl to GOBIN
 .PHONY: generate
 # Generate code
 generate: ## Generates code 
-ifeq (, $(shell which controller-gen))
+ifneq ($(shell go list -f '{{.Version}}' -m sigs.k8s.io/controller-tools), $(shell controller-gen --version 2>/dev/null | cut -b 10-))
+	@echo "(Re-)installing controller-gen. Current version:  $(controller-gen --version 2>/dev/null | cut -b 10-). Need $(go list -f '{{.Version}}' -m sigs.k8s.io/controller-tools)"
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@$$(go list -f '{{.Version}}' -m sigs.k8s.io/controller-tools)
 endif
 	controller-gen crd paths=./pkg/apis/... output:crd:dir=config/crds output:stdout

--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#####
+#  Used to ensure that running `make generate` results in a non-dirty repository.
+#  Used to verify that make generate wasn't forgotten for changes that may require generation.
+#####
+
+set -o nounset
+set -o pipefail
+# intentionally not setting 'set -o errexit' because we want to print custom error messages
+
+# versions of tools
+echo "controller-gen $(controller-gen --version)"
+
+# make sure make generate can be invoked
+make generate
+RETVAL=$?
+if [[ ${RETVAL} != 0 ]]; then
+    echo "Invoking 'make generate' ends with non-zero exit code."
+    exit 1
+fi
+
+git diff --exit-code --quiet
+RETVAL=$?
+
+if [[ ${RETVAL} != 0 ]]; then
+    echo "Running 'make generate' produces changes to the current git status. Maybe you forgot to check-in your updated generated files?"
+    echo "The current diff: $(git diff)"
+    exit 1
+fi
+
+echo "Verifying 'make generate' was successful! ヽ(•‿•)ノ"
+exit 0

--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -25,7 +25,8 @@ RETVAL=$?
 
 if [[ ${RETVAL} != 0 ]]; then
     echo "Running 'make generate' produces changes to the current git status. Maybe you forgot to check-in your updated generated files?"
-    echo "The current diff: $(git diff)"
+    echo "The current diff:"
+    git diff
     exit 1
 fi
 


### PR DESCRIPTION
Signed-off-by: Ken Sipe <kensipe@gmail.com>

**What this PR does / why we need it**:
This adds a `verify-generate.sh` script which runs `make generate` and ensures that the repo isn't "dirty" after.  This is to ensure that changes which require generation are catch in CI.  This PR adds that check to the circleCI target as well.

Fixes #198 
