### PR TITLE
Increasing errcheck Linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ run:
 linters-settings:
   errcheck:
     check-type-assertions: true
+    check-blank: true
   lll:
     line-length: 250
   dupl:
@@ -29,3 +30,9 @@ linters-settings:
   goimports:
     # Don't use 'github.com/kudobuilder/kuttl', it'll result in unreliable output!
     local-prefixes: github.com/kudobuilder
+issues:
+  # ignore errchecks for test files
+  exclude-rules:
+  - path: _test\.go
+    linters:
+    - errcheck

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -246,7 +246,13 @@ func (h *Harness) Config() (*rest.Config, error) {
 	} else {
 		h.T.Log("running tests using configured kubeconfig.")
 		h.config, err = config.GetConfig()
-		inCluster, _ := testutils.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+		inCluster, err := testutils.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
 		if err == nil && inCluster {
 			return h.config, nil
 		}
@@ -511,11 +517,14 @@ func (h *Harness) Stop() {
 	}
 
 	if h.TestSuite.SkipClusterDelete {
-		cwd, _ := os.Getwd()
+		cwd, err := os.Getwd()
+		if err != nil {
+			h.T.Logf("issue getting work directory %v", err)
+		}
 		kubeconfig := filepath.Join(cwd, "kubeconfig")
 
 		h.T.Log("skipping cluster tear down")
-		h.T.Log(fmt.Sprintf("to connect to the cluster, run: export KUBECONFIG=\"%s\"", kubeconfig))
+		h.T.Logf("to connect to the cluster, run: export KUBECONFIG=\"%s\"", kubeconfig)
 
 		return
 	}

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -582,7 +582,7 @@ func InstallManifests(ctx context.Context, client client.Client, dClient discove
 
 // ObjectKey returns an instantiated ObjectKey for the provided object.
 func ObjectKey(obj runtime.Object) client.ObjectKey {
-	m, _ := meta.Accessor(obj)
+	m, _ := meta.Accessor(obj) //nolint:errcheck // runtime.Object don't have the error issues of interface{}
 	return client.ObjectKey{
 		Name:      m.GetName(),
 		Namespace: m.GetNamespace(),
@@ -648,7 +648,7 @@ func NewPod(name, namespace string) runtime.Object {
 func WithNamespace(obj runtime.Object, namespace string) runtime.Object {
 	obj = obj.DeepCopyObject()
 
-	m, _ := meta.Accessor(obj)
+	m, _ := meta.Accessor(obj) //nolint:errcheck // runtime.Object don't have the error issues of interface{}
 	m.SetNamespace(namespace)
 
 	return obj
@@ -706,7 +706,7 @@ func WithLabels(t *testing.T, obj runtime.Object, labels map[string]string) runt
 func WithAnnotations(obj runtime.Object, annotations map[string]string) runtime.Object {
 	obj = obj.DeepCopyObject()
 
-	m, _ := meta.Accessor(obj)
+	m, _ := meta.Accessor(obj) //nolint:errcheck // runtime.Object don't have the error issues of interface{}
 	m.SetAnnotations(annotations)
 
 	return obj
@@ -801,7 +801,7 @@ func CreateOrUpdate(ctx context.Context, cl client.Client, obj runtime.Object, r
 func SetAnnotation(obj runtime.Object, key, value string) runtime.Object {
 	obj = obj.DeepCopyObject()
 
-	meta, _ := meta.Accessor(obj)
+	meta, _ := meta.Accessor(obj) //nolint:errcheck // runtime.Object don't have the error issues of interface{}
 
 	annotations := meta.GetAnnotations()
 	if annotations == nil {


### PR DESCRIPTION
Cranked up errcheck checking so we don't ignore error checks.
Turned it off for tests.. there are times when that is convenient.

3 time ignoring (//nolint), because deep understanding showed that the param type `interface{}` could not be a kube object... however the calling function takes a `runtime.Object` which is a kube object.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

