### PR TITLE
Allow the use of absolute paths in RuntimeObjectsFromPath

### DIFF
--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -553,8 +553,7 @@ func RuntimeObjectsFromPath(path, dir string) ([]runtime.Object, error) {
 	var err error
 	var paths []string
 
-	// if it's an absolute path
-	if len(path) > 0 && path[0] == filepath.Separator {
+	if filepath.IsAbs(path) {
 		paths, err = kfile.FromPath(path, "*.yaml")
 		if err != nil {
 			return nil, fmt.Errorf("failed to find YAML files in %s: %w", path, err)

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -550,9 +550,20 @@ func RuntimeObjectsFromPath(path, dir string) ([]runtime.Object, error) {
 	}
 
 	// it's a directory or file
-	paths, err := kfile.FromPath(filepath.Join(dir, path), "*.yaml")
-	if err != nil {
-		return nil, fmt.Errorf("failed to find YAML files in %s: %w", filepath.Join(dir, path), err)
+	var err error
+	var paths []string
+
+	// if it's an absolute path
+	if len(path) > 0 && path[0] == filepath.Separator {
+		paths, err = kfile.FromPath(path, "*.yaml")
+		if err != nil {
+			return nil, fmt.Errorf("failed to find YAML files in %s: %w", path, err)
+		}
+	} else {
+		paths, err = kfile.FromPath(filepath.Join(dir, path), "*.yaml")
+		if err != nil {
+			return nil, fmt.Errorf("failed to find YAML files in %s: %w", filepath.Join(dir, path), err)
+		}
 	}
 	apply, err := kfile.ToRuntimeObjects(paths)
 	if err != nil {

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -550,23 +550,22 @@ func RuntimeObjectsFromPath(path, dir string) ([]runtime.Object, error) {
 	}
 
 	// it's a directory or file
-	var err error
-	var paths []string
-
-	if filepath.IsAbs(path) {
-		paths, err = kfile.FromPath(path, "*.yaml")
-		if err != nil {
-			return nil, fmt.Errorf("failed to find YAML files in %s: %w", path, err)
-		}
-	} else {
-		paths, err = kfile.FromPath(filepath.Join(dir, path), "*.yaml")
-		if err != nil {
-			return nil, fmt.Errorf("failed to find YAML files in %s: %w", filepath.Join(dir, path), err)
-		}
+	cPath := cleanPath(path, dir)
+	paths, err := kfile.FromPath(cPath, "*.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find YAML files in %s: %w", cPath, err)
 	}
 	apply, err := kfile.ToRuntimeObjects(paths)
 	if err != nil {
 		return nil, err
 	}
 	return apply, nil
+}
+
+// cleanPath returns either the abs path or the joined path
+func cleanPath(path, dir string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(dir, path)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Allow the use of absolute paths in RuntimeObjectsFromPath. Without this an absolute path still has the test directory prepended.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #204
