### PR TITLE
fixes nil ptr panic bug

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -117,8 +117,8 @@ func Retry(ctx context.Context, fn func(context.Context) error, errValidationFun
 			// the common case is when a shared refernence, like a client, is nil and is called in the function
 			defer func() {
 				if r := recover(); r != nil {
-					log.Println("retry func has panicked and will be ignored")
-					doneCh <- struct{}{}
+					//log.Println("retry func has panicked and will be ignored")
+					errCh <- errors.New("func passed to retry panicked.  expected if testsuite is shutting down")
 				}
 			}()
 

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -114,7 +114,7 @@ func Retry(ctx context.Context, fn func(context.Context) error, errValidationFun
 
 		go func() {
 			// if the func we are calling panics, clean up and call it done
-			// the common case is when a shared refernence, like a client, is nil and is called in the function
+			// the common case is when a shared reference, like a client, is nil and is called in the function
 			defer func() {
 				if r := recover(); r != nil {
 					//log.Println("retry func has panicked and will be ignored")

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -131,7 +131,7 @@ func TestRetryWithNilFromFn(t *testing.T) {
 func TestRetryWithNilInFn(t *testing.T) {
 	client := RetryClient{}
 	var list runtime.Object
-	assert.Equal(t, nil, Retry(context.TODO(), func(ctx context.Context) error {
+	assert.Error(t, Retry(context.TODO(), func(ctx context.Context) error {
 		return client.Client.List(ctx, list)
 	}, IsJSONSyntaxError))
 }

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -128,7 +128,7 @@ func TestRetryWithNilFromFn(t *testing.T) {
 	}, IsJSONSyntaxError))
 }
 
-func TestRetryWithNilWithFn(t *testing.T) {
+func TestRetryWithNilInFn(t *testing.T) {
 	client := RetryClient{}
 	var list runtime.Object
 	assert.Equal(t, nil, Retry(context.TODO(), func(ctx context.Context) error {

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -118,6 +118,24 @@ func TestRetryWithUnexpectedError(t *testing.T) {
 	assert.Equal(t, 1, index)
 }
 
+func TestRetryWithNil(t *testing.T) {
+	assert.Equal(t, nil, Retry(context.TODO(), nil, IsJSONSyntaxError))
+}
+
+func TestRetryWithNilFromFn(t *testing.T) {
+	assert.Equal(t, nil, Retry(context.TODO(), func(ctx context.Context) error {
+		return nil
+	}, IsJSONSyntaxError))
+}
+
+func TestRetryWithNilWithFn(t *testing.T) {
+	client := RetryClient{}
+	var list runtime.Object
+	assert.Equal(t, nil, Retry(context.TODO(), func(ctx context.Context) error {
+		return client.Client.List(ctx, list)
+	}, IsJSONSyntaxError))
+}
+
 func TestRetryWithTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()


### PR DESCRIPTION
Defensive recovery for retry logic on a goroutine which is using a shared reference to something that could be cleaned up.

Signed-off-by: Ken Sipe <kensipe@gmail.com>


Fixes #202
