### PR TITLE
Log more details in events.

### DIFF
--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -150,9 +150,31 @@ func (t *Case) CollectEvents(namespace string) {
 
 func printEvents(events []eventsbeta1.Event, logger conversion.DebugLogger) {
 	for _, e := range events {
-		// time type reason kind message
-		logger.Logf("%s\t%s\t%s\t%s", e.ObjectMeta.CreationTimestamp, e.Type, e.Reason, e.Note)
+		// time type regarding action reason note reportingController related
+		logger.Logf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
+			e.ObjectMeta.CreationTimestamp,
+			e.Type,
+			shortString(&e.Regarding),
+			e.Action,
+			e.Reason,
+			e.Note,
+			e.ReportingController,
+			shortString(e.Related))
 	}
+}
+
+func shortString(obj *corev1.ObjectReference) string {
+	if obj == nil {
+		return ""
+	}
+	fieldRef := ""
+	if obj.FieldPath != "" {
+		fieldRef = "." + obj.FieldPath
+	}
+	return fmt.Sprintf("%s %s%s",
+		obj.GroupVersionKind().GroupKind().String(),
+		obj.Name,
+		fieldRef)
 }
 
 // Run runs a test case including all of its steps.


### PR DESCRIPTION
**What this PR does / why we need it**:

Log more details in events to help debugging test issues.

In particular, log the `GroupKind` and `name` of the object in question, which was previously the elephant in the room.

Where non-empty, also log the field path. Also attempt to log the component name and secondary object, if present.

Order the fields such that they read somewhat naturally:
```
timestamp severity kind.group name.field action note
```
for example:
```
2020-10-06 08:00:45 +0000 UTC	Warning	Route.serving.knative.dev mnist-predictor-default	InternalError	failed to update Ingress: Operation cannot be fulfilled on ingresses.networking.internal.knative.dev "mnist-predictor-default": the object has been modified; please apply your changes to the latest version and try again
2020-10-06 08:01:27 +0000 UTC	Normal	Pod test-bucket-delete-jd6xm.spec.containers{mc-rb}	Pulled		Successfully pulled image "minio/mc:RELEASE.2020-08-20T00-23-01Z"
```