### PR TITLE
Add a `tail` parameter to pod collector.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,15 +42,18 @@ You can find the full text of the DCO here: https://developercertificate.org/
 ### Build Instructions
 
 - Get the KUTTL repo: `git clone https://github.com/kudobuilder/kuttl.git`
-- `cd kudo`
-- `make all` to build manager as well as CLI
+- `cd kuttl`
+- `make cli` to build the CLI
 
-#### Testing new CLI
-You can build CLI locally via `make cli`. After running that command, CLI will be available in `bin/kubectl-kuttl` and you can invoke the command for example like this `bin/kubectl-kuttl version` (no need to install it as kubectl plugin).
+After running this command, CLI will be available in `bin/kubectl-kuttl` and you can invoke the command for example like this `bin/kubectl-kuttl version` (no need to install it as `kubectl` plugin).
 
 ### Testing
 
-See the [contributor's testing guide](https://github.com/kudobuilder/kudo/blob/main/test/README.md).
+Use `make all` to run all available tests.
+Run just `make` to see what individual targets are available.
+
+The project has settled on the [testify](https://github.com/stretchr/testify) library for testing purposes.
+Please use it for new tests as well if possible.
 
 ## Community, Discussion, and Support
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/thoas/go-funk v0.7.0
 	gopkg.in/yaml.v2 v2.3.0
-	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.19.2
 	k8s.io/apiextensions-apiserver v0.19.2
 	k8s.io/apimachinery v0.19.2

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/thoas/go-funk v0.7.0
 	gopkg.in/yaml.v2 v2.3.0
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.19.2
 	k8s.io/apiextensions-apiserver v0.19.2
 	k8s.io/apimachinery v0.19.2

--- a/pkg/apis/testharness/v1beta1/collector.go
+++ b/pkg/apis/testharness/v1beta1/collector.go
@@ -125,6 +125,14 @@ func podCommand(tc *TestCollector) *Command {
 	} else {
 		b.WriteString(" --all-containers")
 	}
+	if tc.Tail == 0 {
+		if len(tc.Selector) > 0 {
+			tc.Tail = 10
+		} else {
+			tc.Tail = -1
+		}
+	}
+	fmt.Fprintf(&b, " --tail=%d", tc.Tail)
 	return &Command{
 		Command:       b.String(),
 		IgnoreFailure: true,

--- a/pkg/apis/testharness/v1beta1/collector_test.go
+++ b/pkg/apis/testharness/v1beta1/collector_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTestCollector_String(t *testing.T) {
@@ -153,7 +153,7 @@ func TestPodCommand(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := podCommand(&tt.tc)
-			assert.DeepEqual(t, cmd.Command, tt.cmd) // DeepEqual to get nice context diff on failure
+			assert.Equal(t, cmd.Command, tt.cmd)
 		})
 	}
 }

--- a/pkg/apis/testharness/v1beta1/collector_test.go
+++ b/pkg/apis/testharness/v1beta1/collector_test.go
@@ -3,6 +3,8 @@ package v1beta1
 import (
 	"strings"
 	"testing"
+
+	"gotest.tools/assert"
 )
 
 func TestTestCollector_String(t *testing.T) {
@@ -116,6 +118,42 @@ func TestTestCollector_String(t *testing.T) {
 			if !strings.Contains(got, tt.contains) {
 				t.Errorf("String() = %v, does not contain %v", got, tt.contains)
 			}
+		})
+	}
+}
+
+func TestPodCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		tc   TestCollector
+		cmd  string
+	}{
+		{
+			name: "selector with default tail",
+			tc:   TestCollector{Type: pod, Selector: "x=y"},
+			cmd:  "kubectl logs --prefix -l x=y -n $NAMESPACE --all-containers --tail=10",
+		},
+		{
+			name: "pod name with default tail",
+			tc:   TestCollector{Type: pod, Pod: "foo"},
+			cmd:  "kubectl logs --prefix foo -n $NAMESPACE --all-containers --tail=-1",
+		},
+		{
+			name: "selector with set tail",
+			tc:   TestCollector{Type: pod, Selector: "x=y", Tail: 42},
+			cmd:  "kubectl logs --prefix -l x=y -n $NAMESPACE --all-containers --tail=42",
+		},
+		{
+			name: "pod name with set tail",
+			tc:   TestCollector{Type: pod, Pod: "foo", Tail: 42},
+			cmd:  "kubectl logs --prefix foo -n $NAMESPACE --all-containers --tail=42",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := podCommand(&tt.tc)
+			assert.DeepEqual(t, cmd.Command, tt.cmd) // DeepEqual to get nice context diff on failure
 		})
 	}
 }

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -156,6 +156,10 @@ type TestCollector struct {
 	Container string `json:"container,omitempty"`
 	// Selector is a label query to select pod.
 	Selector string `json:"selector,omitempty"`
+	// Tail is the number of last lines to collect from pods. If omitted or zero,
+	// then the default is 10 if you use a selector, or -1 (all) if you use a pod name.
+	// This matches default behavior of `kubectl logs`.
+	Tail int `json:"tail,omitempty"`
 	// Cmd is a command to run for collection.  It requires an empty Type or Type=command
 	Cmd string `json:"command,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Ability to set the number of lines to collect.
Also minor improvements to contributor guide.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #216