### PR TITLE
dedupe warning messages for deprecated API warnings

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -246,6 +246,7 @@ func (h *Harness) Config() (*rest.Config, error) {
 	} else {
 		h.T.Log("running tests using configured kubeconfig.")
 		h.config, err = config.GetConfig()
+		h.config.WarningHandler = rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{Deduplicate: true})
 		if err != nil {
 			return nil, err
 		}
@@ -253,7 +254,7 @@ func (h *Harness) Config() (*rest.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err == nil && inCluster {
+		if inCluster {
 			return h.config, nil
 		}
 	}


### PR DESCRIPTION
After solving this for kudo https://github.com/kudobuilder/kudo/pull/1712 
It made sense to add it to KUTTL

Signed-off-by: Ken Sipe <kensipe@gmail.com>

