### PR TITLE
Better KUTTL Testing Context

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -271,6 +271,7 @@ func (h *Harness) Config() (*rest.Config, error) {
 		if err != nil {
 			return h.config, err
 		}
+		h.T.Logf("Successful connection to cluster at: %s", h.config.Host)
 	}
 
 	// The creation of the "kubeconfig" is necessary for out of cluster execution of kubectl
@@ -350,6 +351,7 @@ func (h *Harness) RunTests() {
 		if err != nil {
 			h.T.Fatal(err)
 		}
+		h.T.Logf("testsuite: %s has %d tests", testDir, len(tempTests))
 		// array of test cases tied to testsuite (by testdir)
 		realTestSuite[testDir] = tempTests
 	}


### PR DESCRIPTION
Recent challenges by new KUTTLers, it was hard to know:
1. Was the connection with kubernetes cluster working and 
2. Was kuttl pointing to the correct location for tests

This PR resolves that... KUTTL previously had connect failure messages with:
Bad local config
```
 harness.go:572: fatal error getting client: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```
or bad connection with:
```
harness.go:572: fatal error getting client: Get "https://127.0.0.1:63473/api?timeout=32s": dial tcp 127.0.0.1:63473: connect: connection refused
```
However... the absence of this doesn't reinforce comfort... this PR adds the following message after a good connection:
```
 harness.go:274: Successful connection to cluster: https://127.0.0.1:63473
```

Additionally, it is hard to know if users are pointing their testsuite dir to the right location... Adding in a message that will indicates that:

```
harness.go:354: testsuite: /Users/kensipe/projects/playground/e2e has 1 tests
```

Signed-off-by: Ken Sipe <kensipe@gmail.com>

