### PR TITLE
Adding warning message for non-supported version of kind config file.

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -136,7 +136,7 @@ func (h *Harness) RunKIND() (*rest.Config, error) {
 		if h.TestSuite.KINDConfig != "" {
 			h.T.Logf("Loading KIND config from %s", h.TestSuite.KINDConfig)
 			var err error
-			kindCfg, err = loadKindConfig(h.TestSuite.KINDConfig)
+			kindCfg, err = h.loadKindConfig(h.TestSuite.KINDConfig)
 			if err != nil {
 				return nil, err
 			}
@@ -583,7 +583,7 @@ func (h *Harness) Report() {
 	}
 }
 
-func loadKindConfig(path string) (*kindConfig.Cluster, error) {
+func (h *Harness) loadKindConfig(path string) (*kindConfig.Cluster, error) {
 	raw, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -597,6 +597,8 @@ func loadKindConfig(path string) (*kindConfig.Cluster, error) {
 	if err := decoder.Decode(cluster); err != nil {
 		return nil, err
 	}
-
+	if !IsMinVersion(cluster.APIVersion) {
+		h.T.Logf("Warning: %q in %s is not a supported version.\n", cluster.APIVersion, path)
+	}
 	return cluster, nil
 }

--- a/pkg/test/kind.go
+++ b/pkg/test/kind.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
@@ -105,4 +106,11 @@ func loadContainer(docker testutils.DockerClient, node nodes.Node, container str
 	}
 
 	return nil
+}
+
+// IsMinVersion checks if pass ver is the min required kind version
+func IsMinVersion(ver string) bool {
+	minVersion := "kind.sigs.k8s.io/v1alpha4"
+	comp := version.CompareKubeAwareVersionStrings(minVersion, ver)
+	return comp != -1
 }

--- a/pkg/test/kind_test.go
+++ b/pkg/test/kind_test.go
@@ -1,0 +1,45 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckVersion(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		ver      string
+		expected bool
+	}{
+		{
+			name:     `current version`,
+			ver:      "kind.sigs.k8s.io/v1alpha4",
+			expected: true,
+		},
+		{
+			name:     `early version`,
+			ver:      "kind.sigs.k8s.io/v1alpha3",
+			expected: false,
+		},
+		{
+			name:     `newer version`,
+			ver:      "kind.sigs.k8s.io/v1beta1",
+			expected: true,
+		},
+		{
+			name:     `wrong group`,
+			ver:      "foo/v1alpha4",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsMinVersion(tt.ver)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Recent bump in Kind version https://github.com/kudobuilder/kuttl/pull/229 which had a break change in supported versions (in that it removed a version) surfaced the need to communicate this.  This PR does that.

The warning message is:
```
harness.go:601: Warning: "kind.sigs.k8s.io/v1alpha3" in kind.yaml is not a supported version.
```

It is possible if the configuration structure of earlier versions are still supported that everything runs fine... for this reason it was deemed not an error but a warning.  If there is a structural error... the decode code will throw an error... however it is nice to let users know that they need to consider looking at a version update even if theirs works.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #231 
