### PR TITLE
Support CRD v1 creation

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -19,6 +19,7 @@ import (
 	volumetypes "github.com/docker/docker/api/types/volume"
 	docker "github.com/docker/docker/client"
 	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -458,8 +459,11 @@ func (h *Harness) Setup() {
 	}
 
 	// Install CRDs
-	crdKind := testutils.NewResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "", "")
-	crds, err := testutils.InstallManifests(context.TODO(), cl, dClient, h.TestSuite.CRDDir, crdKind)
+	crdKinds := []runtime.Object{
+		testutils.NewResource("apiextensions.k8s.io/v1", "CustomResourceDefinition", "", ""),
+		testutils.NewResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "", ""),
+	}
+	crds, err := testutils.InstallManifests(context.TODO(), cl, dClient, h.TestSuite.CRDDir, crdKinds...)
 	if err != nil {
 		h.fatal(fmt.Errorf("fatal error installing crds: %v", err))
 	}

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -488,6 +488,7 @@ func LoadYAMLFromFile(path string) ([]runtime.Object, error) {
 	return LoadYAML(path, opened)
 }
 
+// LoadYAML loads all objects from a reader
 func LoadYAML(path string, r io.Reader) ([]runtime.Object, error) {
 	yamlReader := yaml.NewYAMLReader(bufio.NewReader(r))
 
@@ -663,6 +664,32 @@ func NewClusterRoleBinding(apiVersion, kind, name, namespace string, serviceAcco
 // NewPod creates a new pod object.
 func NewPod(name, namespace string) runtime.Object {
 	return NewResource("v1", "Pod", name, namespace)
+}
+
+// NewCRDv1 creates a new CRD object of version v1
+func NewCRDv1(t *testing.T, name, group, resourceKind string, resourceVersions []string) runtime.Object {
+	crdVersions := []interface{}{}
+	for _, v := range resourceVersions {
+		crdVersions = append(crdVersions, interface{}(map[string]interface{}{"name": interface{}(v)}))
+	}
+	return WithSpec(t, NewResource("apiextensions.k8s.io/v1", "CustomResourceDefinition", name, ""), map[string]interface{}{
+		"versions": crdVersions,
+		"group":    interface{}(group),
+		"names": interface{}(map[string]interface{}{
+			"kind": interface{}(resourceKind),
+		}),
+	})
+}
+
+// NewCRDv1beta1 creates a new CRD object of version v1beta1
+func NewCRDv1beta1(t *testing.T, name, group, resourceKind, resourceVersion string) runtime.Object {
+	return WithSpec(t, NewResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", name, ""), map[string]interface{}{
+		"version": resourceVersion,
+		"group":   interface{}(group),
+		"names": interface{}(map[string]interface{}{
+			"kind": interface{}(resourceKind),
+		}),
+	})
 }
 
 // WithNamespace naively applies the namespace to the object. Used mainly in tests, otherwise
@@ -904,39 +931,9 @@ func WaitForSA(config *rest.Config, name, namespace string) error {
 
 // WaitForCRDs waits for the provided CRD types to be available in the Kubernetes API.
 func WaitForCRDs(dClient discovery.DiscoveryInterface, crds []runtime.Object) error {
-	waitingFor := []schema.GroupVersionKind{}
-	crdV1Kind := NewResource("apiextensions.k8s.io/v1", "CustomResourceDefinition", "", "")
-	crdV1beta1Kind := NewResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "", "")
-
-	for _, crdObj := range crds {
-		if !MatchesKind(crdObj, crdV1Kind, crdV1beta1Kind) {
-			return fmt.Errorf("the following passed object does not match %v: %v", crdV1Kind, crdObj)
-		}
-
-		switch crd := crdObj.(type) {
-		case *apiextv1.CustomResourceDefinition:
-			for _, version := range crd.Spec.Versions {
-				waitingFor = append(waitingFor, schema.GroupVersionKind{
-					Group:   crd.Spec.Group,
-					Version: version.Name,
-					Kind:    crd.Spec.Names.Kind,
-				})
-			}
-		case *apiextv1beta1.CustomResourceDefinition:
-			waitingFor = append(waitingFor, schema.GroupVersionKind{
-				Group:   crd.Spec.Group,
-				Version: crd.Spec.Version,
-				Kind:    crd.Spec.Names.Kind,
-			})
-		case *unstructured.Unstructured:
-			waitingFor = append(waitingFor, schema.GroupVersionKind{
-				Group:   crd.Object["spec"].(map[string]interface{})["group"].(string),
-				Version: crd.Object["spec"].(map[string]interface{})["version"].(string),
-				Kind:    crd.Object["spec"].(map[string]interface{})["names"].(map[string]interface{})["kind"].(string),
-			})
-		default:
-			return fmt.Errorf("the following passed object is not a CRD: %v", crdObj)
-		}
+	waitingFor, err := ExtractGVKFromCRD(crds)
+	if err != nil {
+		return err
 	}
 
 	return wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
@@ -1220,6 +1217,7 @@ func Kubeconfig(cfg *rest.Config, w io.Writer) error {
 	}, w)
 }
 
+// GetDiscoveryClient returns an instance of discovery client
 func GetDiscoveryClient(mgr manager.Manager) (*discovery.DiscoveryClient, error) {
 	// use manager rest config to create a discovery client
 	dc, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
@@ -1240,4 +1238,58 @@ func InClusterConfig() (bool, error) {
 		return false, nil
 	}
 	return false, err
+}
+
+// ExtractGVKFromCRD extracts GroupVersionKinds from the given CRDs
+func ExtractGVKFromCRD(crds []runtime.Object) ([]schema.GroupVersionKind, error) {
+	gvks := []schema.GroupVersionKind{}
+
+	crdV1Kind := NewResource("apiextensions.k8s.io/v1", "CustomResourceDefinition", "", "")
+	crdV1beta1Kind := NewResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "", "")
+
+	for _, crdObj := range crds {
+		v1Kind, v1Beta1Kind := MatchesKind(crdObj, crdV1Kind), MatchesKind(crdObj, crdV1beta1Kind)
+		if !v1Kind && !v1Beta1Kind {
+			return nil, fmt.Errorf("the following passed object does not match %v or %v: %v", crdV1Kind, crdV1beta1Kind, crdObj)
+		}
+
+		switch crd := crdObj.(type) {
+		case *apiextv1.CustomResourceDefinition:
+			for _, version := range crd.Spec.Versions {
+				gvks = append(gvks, schema.GroupVersionKind{
+					Group:   crd.Spec.Group,
+					Version: version.Name,
+					Kind:    crd.Spec.Names.Kind,
+				})
+			}
+		case *apiextv1beta1.CustomResourceDefinition:
+			gvks = append(gvks, schema.GroupVersionKind{
+				Group:   crd.Spec.Group,
+				Version: crd.Spec.Version,
+				Kind:    crd.Spec.Names.Kind,
+			})
+		case *unstructured.Unstructured:
+			spec := crd.Object["spec"].(map[string]interface{})
+			switch {
+			case v1Kind:
+				for _, ver := range spec["versions"].([]interface{}) {
+					gvks = append(gvks, schema.GroupVersionKind{
+						Group:   spec["group"].(string),
+						Version: ver.(map[string]interface{})["name"].(string),
+						Kind:    spec["names"].(map[string]interface{})["kind"].(string),
+					})
+				}
+			case v1Beta1Kind:
+				gvks = append(gvks, schema.GroupVersionKind{
+					Group:   spec["group"].(string),
+					Version: spec["version"].(string),
+					Kind:    spec["names"].(map[string]interface{})["kind"].(string),
+				})
+			}
+		default:
+			return nil, fmt.Errorf("the following passed object is not a CRD: %v", crdObj)
+		}
+	}
+
+	return gvks, nil
 }

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -10,7 +10,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -493,5 +497,153 @@ func TestRunScript(t *testing.T) {
 				assert.True(t, stdout.Len() == 0)
 			}
 		})
+	}
+}
+
+func TestExtractGVKFromCRD(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		inputCRDs    []runtime.Object
+		expectedGVKs []schema.GroupVersionKind
+		shouldError  bool
+	}{
+		{
+			name: "Nominal. Unstructured CRDs",
+			inputCRDs: []runtime.Object{
+				NewCRDv1(t, "test", "test.net", "testresource", []string{"v1alpha1", "v1alpha2"}),
+				NewCRDv1beta1(t, "test2", "test.net", "testresource2", "v1beta1"),
+				NewCRDv1beta1(t, "test3", "test.net", "testresource3", "v1"),
+			},
+			expectedGVKs: []schema.GroupVersionKind{
+				{
+					Group:   "test.net",
+					Version: "v1alpha1",
+					Kind:    "testresource",
+				},
+				{
+					Group:   "test.net",
+					Version: "v1alpha2",
+					Kind:    "testresource",
+				},
+				{
+					Group:   "test.net",
+					Version: "v1beta1",
+					Kind:    "testresource2",
+				},
+				{
+					Group:   "test.net",
+					Version: "v1",
+					Kind:    "testresource3",
+				},
+			},
+		},
+		{
+			name: "Structured CRDs",
+			inputCRDs: []runtime.Object{
+				newTestCRDv1("test", "test.net", "testresource", []string{"v1alpha1", "v1alpha2"}),
+				newTestCRDv1beta1("test2", "test.net", "testresource2", "v1beta1"),
+				newTestCRDv1beta1("test3", "test.net", "testresource3", "v1"),
+			},
+			expectedGVKs: []schema.GroupVersionKind{
+				{
+					Group:   "test.net",
+					Version: "v1alpha1",
+					Kind:    "testresource",
+				},
+				{
+					Group:   "test.net",
+					Version: "v1alpha2",
+					Kind:    "testresource",
+				},
+				{
+					Group:   "test.net",
+					Version: "v1beta1",
+					Kind:    "testresource2",
+				},
+				{
+					Group:   "test.net",
+					Version: "v1",
+					Kind:    "testresource3",
+				},
+			},
+		},
+		{
+			name: "Error. Wrong kind",
+			inputCRDs: []runtime.Object{
+				NewResource("apiextensions.k8s.io/v1alpha1", "CustomResourceDefinition", "", ""),
+			},
+			shouldError: true,
+		},
+		{
+			name: "Error. Wrong type",
+			inputCRDs: []runtime.Object{
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
+			shouldError: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			gotGVKs, err := ExtractGVKFromCRD(test.inputCRDs)
+			if test.shouldError {
+				assert.NotNil(t, err)
+				assert.Nil(t, gotGVKs)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, test.expectedGVKs, gotGVKs)
+			}
+		})
+	}
+}
+
+func newTestCRDv1(name, group, resourceKind string, resourceVersions []string) *apiextv1.CustomResourceDefinition {
+	crdVersions := []apiextv1.CustomResourceDefinitionVersion{}
+	for _, v := range resourceVersions {
+		crdVersions = append(crdVersions, apiextv1.CustomResourceDefinitionVersion{
+			Name: v,
+		})
+	}
+
+	return &apiextv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CustomResourceDefinition",
+			APIVersion: "apiextensions.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: apiextv1.CustomResourceDefinitionSpec{
+			Group:    group,
+			Versions: crdVersions,
+			Names: apiextv1.CustomResourceDefinitionNames{
+				Kind: resourceKind,
+			},
+		},
+	}
+}
+
+func newTestCRDv1beta1(name, group, resourceKind, resourceVersion string) *apiextv1beta1.CustomResourceDefinition {
+	return &apiextv1beta1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CustomResourceDefinition",
+			APIVersion: "apiextensions.k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: apiextv1beta1.CustomResourceDefinitionSpec{
+			Group:   group,
+			Version: resourceVersion,
+			Names: apiextv1beta1.CustomResourceDefinitionNames{
+				Kind: resourceKind,
+			},
+		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Thanks to [PR to support CRD v1](https://github.com/kudobuilder/kuttl/pull/211) it's now possible to wait for CRD of apiVersion v1.

However it's still not possible to create v1 CRDs using `crdDir` in the configuration.

This PR adds the ability to create v1 CRDs, in combination with the waiting mentioned earlier the CRD v1 support should be complete.
