### PR TITLE
Make it possible to attach control-plane logs to stdout

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -24,7 +24,10 @@ type TestSuite struct {
 	StartControlPlane bool `json:"startControlPlane"`
 	// ControlPlaneArgs defaults to APIServerDefaultArgs from controller-runtime pkg/internal/testing/integration/internal/apiserver.go
 	// this allows for control over the args, however these are not serialized from a TestSuite.yaml
-	ControlPlaneArgs []string
+	ControlPlaneArgs []string `json:"controlPlaneArgs"`
+	// AttachControlPlaneOutput if true, attaches control plane logs (api-server, etcd) into stdout. This is useful for debugging.
+	// defaults to false
+	AttachControlPlaneOutput bool `json:"attachControlPlaneOutput"`
 	// Whether or not to start a local kind cluster for the tests.
 	StartKIND bool `json:"startKIND"`
 	// Path to the KIND configuration file to use.

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -47,6 +47,7 @@ func newTestCmd() *cobra.Command {
 	manifestDirs := []string{}
 	testToRun := ""
 	startControlPlane := false
+	attachControlPlaneOutput := false
 	startKIND := false
 	kindConfig := ""
 	kindContext := ""
@@ -125,6 +126,10 @@ For more detailed documentation, visit: https://kuttl.dev`,
 				options.StartControlPlane = startControlPlane
 			}
 
+			if isSet(flags, "attach-control-plane-output") {
+				options.AttachControlPlaneOutput = attachControlPlaneOutput
+			}
+
 			if isSet(flags, "start-kind") {
 				options.StartKIND = startKIND
 			}
@@ -144,6 +149,11 @@ For more detailed documentation, visit: https://kuttl.dev`,
 
 			if options.StartControlPlane && options.StartKIND {
 				return errors.New("only one of --start-control-plane and --start-kind can be set")
+			}
+
+			// after control-plane && start=kind check
+			if options.AttachControlPlaneOutput && !options.StartControlPlane {
+				return errors.New("only use --attach-control-plane-output with --start-control-plane")
 			}
 
 			if isSet(flags, "skip-delete") {
@@ -222,6 +232,7 @@ For more detailed documentation, visit: https://kuttl.dev`,
 	testCmd.Flags().StringSliceVar(&manifestDirs, "manifest-dir", []string{}, "One or more directories containing manifests to apply before running the tests.")
 	testCmd.Flags().StringVar(&testToRun, "test", "", "If set, the specific test case to run.")
 	testCmd.Flags().BoolVar(&startControlPlane, "start-control-plane", false, "Start a local Kubernetes control plane for the tests (requires etcd and kube-apiserver binaries, cannot be used with --start-kind).")
+	testCmd.Flags().BoolVar(&attachControlPlaneOutput, "attach-control-plane-output", false, "Attaches control plane to stdout when using --start-control-plane.")
 	testCmd.Flags().StringVar(&mockControllerFile, "control-plane-config", "", "Path to file to load controller-runtime APIServer configuration arguments (only useful when --startControlPlane).")
 	testCmd.Flags().BoolVar(&startKIND, "start-kind", false, "Start a KIND cluster for the tests (cannot be used with --start-control-plane).")
 	testCmd.Flags().StringVar(&kindConfig, "kind-config", "", "Specify the KIND configuration file path (implies --start-kind, cannot be used with --start-control-plane).")

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -212,7 +212,7 @@ func (h *Harness) addNodeCaches(dockerClient testutils.DockerClient, kindCfg *ki
 func (h *Harness) RunTestEnv() (*rest.Config, error) {
 	started := time.Now()
 
-	testenv, err := testutils.StartTestEnvironment(h.TestSuite.ControlPlaneArgs)
+	testenv, err := testutils.StartTestEnvironment(h.TestSuite.ControlPlaneArgs, h.TestSuite.AttachControlPlaneOutput)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -29,7 +29,7 @@ var testenv testutils.TestEnvironment
 func TestMain(m *testing.M) {
 	var err error
 
-	testenv, err = testutils.StartTestEnvironment(testutils.APIServerDefaultArgs)
+	testenv, err = testutils.StartTestEnvironment(testutils.APIServerDefaultArgs, false)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -969,9 +969,10 @@ type TestEnvironment struct {
 
 // StartTestEnvironment is a wrapper for controller-runtime's envtest that creates a Kubernetes API server and etcd
 // suitable for use in tests.
-func StartTestEnvironment(KubeAPIServerFlags []string) (env TestEnvironment, err error) {
+func StartTestEnvironment(KubeAPIServerFlags []string, attachControlPlaneOutput bool) (env TestEnvironment, err error) {
 	env.Environment = &envtest.Environment{
-		KubeAPIServerFlags: KubeAPIServerFlags,
+		KubeAPIServerFlags:       KubeAPIServerFlags,
+		AttachControlPlaneOutput: attachControlPlaneOutput,
 	}
 
 	env.Config, err = env.Environment.Start()

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -24,7 +24,7 @@ var testenv TestEnvironment
 func TestMain(m *testing.M) {
 	var err error
 
-	testenv, err = StartTestEnvironment(APIServerDefaultArgs)
+	testenv, err = StartTestEnvironment(APIServerDefaultArgs, false)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This is useful when for debugging tests or test setup.