### PR TITLE
fixes to crdv1 lint failures

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1277,7 +1277,10 @@ func ExtractGVKFromCRD(crds []runtime.Object) ([]schema.GroupVersionKind, error)
 				Kind:    crd.Spec.Names.Kind,
 			})
 		case *unstructured.Unstructured:
-			spec := crd.Object["spec"].(map[string]interface{})
+			spec, err := crd.Object["spec"].(map[string]interface{})
+			if err {
+				return nil, fmt.Errorf("the following unstructured object does not cast to a map: %v", crdObj)
+			}
 			switch {
 			case v1Kind:
 				for _, ver := range spec["versions"].([]interface{}) {

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -501,7 +501,8 @@ func TestRunScript(t *testing.T) {
 }
 
 func TestExtractGVKFromCRD(t *testing.T) {
-	for _, test := range []struct {
+
+	tests := []struct {
 		name         string
 		inputCRDs    []runtime.Object
 		expectedGVKs []schema.GroupVersionKind
@@ -536,6 +537,7 @@ func TestExtractGVKFromCRD(t *testing.T) {
 					Kind:    "testresource3",
 				},
 			},
+			shouldError: true,
 		},
 		{
 			name: "Structured CRDs",
@@ -589,15 +591,19 @@ func TestExtractGVKFromCRD(t *testing.T) {
 			},
 			shouldError: true,
 		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			gotGVKs, err := ExtractGVKFromCRD(test.inputCRDs)
-			if test.shouldError {
+	}
+	for _, tt := range tests {
+
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			gotGVKs, err := ExtractGVKFromCRD(tt.inputCRDs)
+			if tt.shouldError {
 				assert.NotNil(t, err)
 				assert.Nil(t, gotGVKs)
 			} else {
 				assert.Nil(t, err)
-				assert.Equal(t, test.expectedGVKs, gotGVKs)
+				assert.Equal(t, tt.expectedGVKs, gotGVKs)
 			}
 		})
 	}


### PR DESCRIPTION
PR https://github.com/kudobuilder/kuttl/pull/237
introduced several lint breakages that were missed for the merge... it also introduced a non-standard approach at collections of tests.   
This resolves that and fixes main

Signed-off-by: Ken Sipe <kensipe@gmail.com>


**What this PR does / why we need it**:

Fixes #
