### PR TITLE
Report 0 testsuites and failed connections

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -234,8 +234,8 @@ func (ts *Testsuites) NewSuite(name string) *Testsuite {
 	return suite
 }
 
-// AddFailure adds a failure to the TestSuites collection for startup failures in the test harness
-func (ts *Testsuites) AddFailure(message string) {
+// SetFailure adds a failure to the TestSuites collection for startup failures in the test harness
+func (ts *Testsuites) SetFailure(message string) {
 	ts.Failure = &Failure{
 		Message: message,
 	}

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -196,6 +196,7 @@ func shortString(obj *corev1.ObjectReference) string {
 func (t *Case) Run(test *testing.T, tc *report.Testcase) {
 	ns := t.determineNamespace()
 	if err := t.CreateNamespace(ns); err != nil {
+		tc.Failure = report.NewFailure(err.Error(), nil)
 		test.Fatal(err)
 	}
 

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -569,7 +569,7 @@ func (h *Harness) Stop() {
 func (h *Harness) fatal(err error) {
 	// clean up on fatal in setup
 	if !h.stopping {
-		h.report.AddFailure(err.Error())
+		h.report.SetFailure(err.Error())
 		// stopping prevents reentry into h.Stop
 		h.stopping = true
 		h.Stop()

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -438,7 +438,6 @@ func (h *Harness) Run() {
 
 	h.Setup()
 	h.RunTests()
-	h.Report()
 }
 
 // Setup spins up the test env based on configuration
@@ -562,18 +561,20 @@ func (h *Harness) Stop() {
 
 		h.kind = nil
 	}
+	h.Report()
 }
 
 // wraps Test.Fatal in order to clean up harness
 // fatal should NOT be used with a go routine, it is not thread safe
-func (h *Harness) fatal(args ...interface{}) {
+func (h *Harness) fatal(err error) {
 	// clean up on fatal in setup
 	if !h.stopping {
+		h.report.AddFailure(err.Error())
 		// stopping prevents reentry into h.Stop
 		h.stopping = true
 		h.Stop()
 	}
-	h.T.Fatal(args...)
+	h.T.Fatal(err)
 }
 
 func (h *Harness) kubeconfigPath() string {


### PR DESCRIPTION
This PR provides the following benefits (read #242 for full context)

* if `--report` is specified, always report.  This will now report even if there are 0 test suites.
* if there is a connection issue the test is "failed".  If `--report` is specified, this will now report with the fatal error information.
* small adjustment for ` (h *Harness) fatal` which was always called with `error` which it was refactor to use.

Signed-off-by: Ken Sipe <kensipe@gmail.com>



Fixes #242 
