### PR TITLE
Updating Linter: Adding gocritic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,29 +1,36 @@
 linters:
   auto-fix: false
   enable:
+    - deadcode
+    - dupl
     - errcheck
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
     - goimports
     - golint
     - gosec
+    - gosimple
+    - ineffassign
+    - lll
     - misspell
+    - nakedret
     - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
     - unconvert
     - unparam
-    - nakedret
-    - gocyclo
-    - dupl
-    - goconst
-    - lll
-    - stylecheck
-    - varcheck
-    - deadcode
-    - structcheck
-    - ineffassign
-    - goconst
-    - staticcheck
     - unused
-    - gosimple
+    - varcheck
 run:
+  skip-dirs:
+    - hack
+    - dist
+    - keps
+    - kind-*
+
 linters-settings:
   errcheck:
     check-type-assertions: true

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -237,14 +237,14 @@ func (h *Harness) Config() (*rest.Config, error) {
 	}
 
 	var err error
-
-	if h.TestSuite.StartControlPlane {
+	switch {
+	case h.TestSuite.StartControlPlane:
 		h.T.Log("running tests with a mocked control plane (kube-apiserver and etcd).")
 		h.config, err = h.RunTestEnv()
-	} else if h.TestSuite.StartKIND {
+	case h.TestSuite.StartKIND:
 		h.T.Log("running tests with KIND.")
 		h.config, err = h.RunKIND()
-	} else {
+	default:
 		h.T.Log("running tests using configured kubeconfig.")
 		h.config, err = config.GetConfig()
 		if err != nil {
@@ -259,7 +259,6 @@ func (h *Harness) Config() (*rest.Config, error) {
 			return h.config, nil
 		}
 	}
-
 	if err != nil {
 		return h.config, err
 	}

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -77,7 +77,7 @@ var APIServerDefaultArgs = []string{
 	"--advertise-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}",
 }
 
-//TODO (kensipe): need to consider options around AlwaysAdmin https://github.com/kudobuilder/kudo/pull/1420/files#r391449597
+// TODO (kensipe): need to consider options around AlwaysAdmin https://github.com/kudobuilder/kudo/pull/1420/files#r391449597
 
 // IsJSONSyntaxError returns true if the error is a JSON syntax error.
 func IsJSONSyntaxError(err error) bool {
@@ -118,7 +118,6 @@ func Retry(ctx context.Context, fn func(context.Context) error, errValidationFun
 			// the common case is when a shared reference, like a client, is nil and is called in the function
 			defer func() {
 				if r := recover(); r != nil {
-					//log.Println("retry func has panicked and will be ignored")
 					errCh <- errors.New("func passed to retry panicked.  expected if testsuite is shutting down")
 				}
 			}()
@@ -395,13 +394,14 @@ func ConvertUnstructured(in runtime.Object) (runtime.Object, error) {
 	if group == kudoGroup {
 		log.Print("WARNING: kudo.dev group has been deprecated and is schedule to be removed in KUTTL 0.8.0")
 	}
-	if (group == kudoGroup || group == kuttlGroup) && kind == "TestStep" {
+	switch {
+	case (group == kudoGroup || group == kuttlGroup) && kind == "TestStep":
 		converted = &harness.TestStep{}
-	} else if (group == kudoGroup || group == kuttlGroup) && kind == "TestAssert" {
+	case (group == kudoGroup || group == kuttlGroup) && kind == "TestAssert":
 		converted = &harness.TestAssert{}
-	} else if (group == kudoGroup || group == kuttlGroup) && kind == "TestSuite" {
+	case (group == kudoGroup || group == kuttlGroup) && kind == "TestSuite":
 		converted = &harness.TestSuite{}
-	} else {
+	default:
 		return in, nil
 	}
 
@@ -973,9 +973,9 @@ type TestEnvironment struct {
 
 // StartTestEnvironment is a wrapper for controller-runtime's envtest that creates a Kubernetes API server and etcd
 // suitable for use in tests.
-func StartTestEnvironment(KubeAPIServerFlags []string, attachControlPlaneOutput bool) (env TestEnvironment, err error) {
+func StartTestEnvironment(kubeAPIServerFlags []string, attachControlPlaneOutput bool) (env TestEnvironment, err error) {
 	env.Environment = &envtest.Environment{
-		KubeAPIServerFlags:       KubeAPIServerFlags,
+		KubeAPIServerFlags:       kubeAPIServerFlags,
 		AttachControlPlaneOutput: attachControlPlaneOutput,
 	}
 

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -394,12 +394,15 @@ func ConvertUnstructured(in runtime.Object) (runtime.Object, error) {
 	if group == kudoGroup {
 		log.Print("WARNING: kudo.dev group has been deprecated and is schedule to be removed in KUTTL 0.8.0")
 	}
+	if !(group == kudoGroup || group == kuttlGroup) {
+		return in, nil
+	}
 	switch {
-	case (group == kudoGroup || group == kuttlGroup) && kind == "TestStep":
+	case kind == "TestStep":
 		converted = &harness.TestStep{}
-	case (group == kudoGroup || group == kuttlGroup) && kind == "TestAssert":
+	case kind == "TestAssert":
 		converted = &harness.TestAssert{}
-	case (group == kudoGroup || group == kuttlGroup) && kind == "TestSuite":
+	case kind == "TestSuite":
 		converted = &harness.TestSuite{}
 	default:
 		return in, nil

--- a/pkg/test/utils/subset.go
+++ b/pkg/test/utils/subset.go
@@ -47,7 +47,8 @@ func IsSubset(expected, actual interface{}) error {
 		return nil
 	}
 
-	if reflect.TypeOf(expected).Kind() == reflect.Slice {
+	switch reflect.TypeOf(expected).Kind() {
+	case reflect.Slice:
 		if reflect.ValueOf(expected).Len() != reflect.ValueOf(actual).Len() {
 			return &SubsetError{
 				message: fmt.Sprintf("slice length mismatch: %d != %d", reflect.ValueOf(expected).Len(), reflect.ValueOf(actual).Len()),
@@ -59,7 +60,7 @@ func IsSubset(expected, actual interface{}) error {
 				return err
 			}
 		}
-	} else if reflect.TypeOf(expected).Kind() == reflect.Map {
+	case reflect.Map:
 		iter := reflect.ValueOf(expected).MapRange()
 
 		for iter.Next() {
@@ -81,7 +82,7 @@ func IsSubset(expected, actual interface{}) error {
 				return err
 			}
 		}
-	} else {
+	default:
 		return &SubsetError{
 			message: fmt.Sprintf("value mismatch, expected: %v != actual: %v", expected, actual),
 		}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -39,7 +39,7 @@ func Get() Info {
 			gitVersion = "dev"
 		}
 		gitCommit = "dev"
-		//TODO (kensipe): add debug message!
+		// TODO (kensipe): add debug message!
 	}
 
 	return Info{


### PR DESCRIPTION
Updated Linters to be alphabetical... it was really hard to see or know if we used a specific linter
added in `gocritic`... and I like it!

Signed-off-by: Ken Sipe <kensipe@gmail.com>
