### PR TITLE
Update to codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @gerred @kensipe @zen-dog @jbarrick-mesosphere @ANeumann82 @porridge @zmalik @jmccormick2001
+*       @kensipe @jbarrick-mesosphere @ANeumann82 @jmccormick2001 @alenkacz
 
 # In this example, @doctocat owns any files in the build/logs
 # directory at the root of the repository and any of its


### PR DESCRIPTION
No change in commit rights... reducing owners to those that have been active in the last quarter.

This is mainly to reduce the GH reviewers that are likely to respond for PR reviews.

Signed-off-by: Ken Sipe <kensipe@gmail.com>
