### PR TITLE
Warning for testdir Override

### DIFF
--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -193,7 +193,7 @@ For more detailed documentation, visit: https://kuttl.dev`,
 			}
 
 			if len(args) != 0 {
-				log.Println("kutt-test config testdirs is overridden with arg: ", args)
+				log.Println("kutt-test config testdirs is overridden with args: [", strings.Join(args, ", "), "]")
 				options.TestDirs = args
 			}
 

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -77,8 +77,6 @@ For more detailed documentation, visit: https://kuttl.dev`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags := cmd.Flags()
 
-			options.TestDirs = args
-
 			// If a config is not set and kuttl-test.yaml exists, set configPath to kuttl-test.yaml.
 			if configPath == "" {
 				if _, err := os.Stat("kuttl-test.yaml"); err == nil {
@@ -195,6 +193,7 @@ For more detailed documentation, visit: https://kuttl.dev`,
 			}
 
 			if len(args) != 0 {
+				log.Println("kutt-test config testdirs is overridden with arg: ", args )
 				options.TestDirs = args
 			}
 

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -193,7 +193,7 @@ For more detailed documentation, visit: https://kuttl.dev`,
 			}
 
 			if len(args) != 0 {
-				log.Println("kutt-test config testdirs is overridden with arg: ", args )
+				log.Println("kutt-test config testdirs is overridden with arg: ", args)
 				options.TestDirs = args
 			}
 


### PR DESCRIPTION
Feedback from community is that overriding the kuttl-test.yaml config testDirs is something that needed to be in the stdout log for awareness.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

