### PR TITLE
pkg/test: allow complex "assert" and "errors" step file names

### DIFF
--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	petname "github.com/dustinkirkland/golang-petname"
-	"github.com/thoas/go-funk"
+	funk "github.com/thoas/go-funk"
 	corev1 "k8s.io/api/core/v1"
 	eventsbeta1 "k8s.io/api/events/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -26,7 +26,8 @@ import (
 	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
 )
 
-var testStepRegex = regexp.MustCompile(`^(\d+)-([^.]+)(.yaml)?$`)
+// testStepRegex contains one capturing group to determine the index of a step file.
+var testStepRegex = regexp.MustCompile(`^(\d+)-(?:[^\.]+)(?:\.yaml)?$`)
 
 // Case contains all of the test steps and the Kubernetes client and other global configuration
 // for a test.
@@ -267,16 +268,13 @@ func (t *Case) CollectTestStepFiles() (map[int64][]string, error) {
 	}
 
 	for _, file := range files {
-		matches := testStepRegex.FindStringSubmatch(file.Name())
-
-		if len(matches) < 2 {
-			t.Logger.Log("Ignoring", file.Name(), "as it does not match file name regexp:", testStepRegex.String())
-			continue
-		}
-
-		index, err := strconv.ParseInt(matches[1], 10, 32)
+		index, err := getIndexFromFile(file.Name())
 		if err != nil {
 			return nil, err
+		}
+		if index < 0 {
+			t.Logger.Log("Ignoring", file.Name(), "as it does not match file name regexp:", testStepRegex.String())
+			continue
 		}
 
 		if testStepFiles[index] == nil {
@@ -302,6 +300,18 @@ func (t *Case) CollectTestStepFiles() (map[int64][]string, error) {
 	}
 
 	return testStepFiles, nil
+}
+
+// getIndexFromFile returns the index derived from fileName's prefix, ex. "01-foo.yaml" has index 1.
+// If an index isn't found, -1 is returned.
+func getIndexFromFile(fileName string) (int64, error) {
+	matches := testStepRegex.FindStringSubmatch(fileName)
+	if len(matches) != 2 {
+		return -1, nil
+	}
+
+	i, err := strconv.ParseInt(matches[1], 10, 32)
+	return i, err
 }
 
 // LoadTestSteps loads all of the test steps for a test case.

--- a/pkg/test/case_test.go
+++ b/pkg/test/case_test.go
@@ -297,3 +297,27 @@ func TestCollectTestStepFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestGetIndexFromFile(t *testing.T) {
+	for _, tt := range []struct {
+		fileName string
+		indexExp int64
+	}{
+		{"00-foo.yaml", 0},
+		{"01-foo.yaml", 1},
+		{"1-foo.yaml", 1},
+		{"01-foo", 1},
+		{"01234-foo.yaml", 1234},
+		{"1-foo-bar.yaml", 1},
+		{"01.yaml", -1},
+		{"foo-01.yaml", -1},
+	} {
+		tt := tt
+
+		t.Run(tt.fileName, func(t *testing.T) {
+			index, err := getIndexFromFile(tt.fileName)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.indexExp, index)
+		})
+	}
+}

--- a/pkg/test/step_test.go
+++ b/pkg/test/step_test.go
@@ -330,3 +330,37 @@ func TestRun(t *testing.T) {
 		})
 	}
 }
+
+func TestPopulateObjectsByFileName(t *testing.T) {
+	for _, tt := range []struct {
+		fileName                   string
+		isAssert, isError, isApply bool
+		name                       string
+		errExp                     bool
+	}{
+		{"00-assert.yaml", true, false, false, "", false},
+		{"00-errors.yaml", false, true, false, "", false},
+		{"00-foo.yaml", false, false, true, "foo", false},
+		{"123-assert.yaml", true, false, false, "", false},
+		{"123-errors.yaml", false, true, false, "", false},
+		{"123-foo.yaml", false, false, true, "foo", false},
+		{"00-assert-bar.yaml", true, false, false, "", false},
+		{"00-errors-bar.yaml", false, true, false, "", false},
+		{"00-foo-bar.yaml", false, false, true, "foo-bar", false},
+		{"00-foo-bar-baz.yaml", false, false, true, "foo-bar-baz", false},
+	} {
+		tt := tt
+
+		t.Run(tt.fileName, func(t *testing.T) {
+			step := &Step{}
+			err := step.populateObjectsByFileName(tt.fileName, []runtime.Object{testutils.NewPod("foo", "")})
+			assert.Nil(t, err)
+			assert.Equal(t, tt.isAssert, len(step.Asserts) != 0)
+			assert.Equal(t, tt.isError, len(step.Errors) != 0)
+			assert.Equal(t, tt.isApply, len(step.Apply) != 0)
+			if tt.isApply && len(step.Apply) != 0 {
+				assert.Equal(t, tt.name, step.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves file name matching regexps by adding meta char escapes and non-capturing groups, and permitts assert- and error-type steps to have complex names, ex. "00-assert-test-pod.yaml"

Signed-off-by: Eric Stroczynski <estroczy@redhat.com>