### PR TITLE
harness: add JSON tag for the `suppress` config option

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -56,17 +56,17 @@ type TestSuite struct {
 
 	// ReportFormat determines test report format (JSON|XML|nil) nil == no report
 	// maps to report.Type, however we don't want generated.deepcopy to have reference to it.
-	ReportFormat string
+	ReportFormat string `json:"reportFormat"`
 
 	// ReportName defines the name of report to create.  It defaults to "kuttl-test" and is not used unless ReportFormat is defined.
-	ReportName string
+	ReportName string `json:"reportName"`
 	// Namespace defines the namespace to use for tests
 	// The value "" means to auto-generate tests namespaces, these namespaces will be created and removed for each test
 	// Any other value is the name of the namespace to use.  This namespace will be created if it does not exist and will
 	// be removed it was created (unless --skipDelete is used).
-	Namespace string
+	Namespace string `json:"namespace"`
 	// Suppress is used to suppress logs
-	Suppress []string
+	Suppress []string `json:"suppress"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -185,8 +185,15 @@ For more detailed documentation, visit: https://kuttl.dev`,
 			}
 
 			if isSet(flags, "suppress-log") {
-				for _, s := range suppress {
-					options.Suppress = append(options.Suppress, strings.ToLower(s))
+				suppressSet := make(map[string]struct{})
+				for _, s := range append(options.Suppress, suppress...) {
+					suppressSet[strings.ToLower(s)] = struct{}{}
+				}
+				options.Suppress = make([]string, len(suppressSet))
+				i := 0
+				for s := range suppressSet {
+					options.Suppress[i] = s
+					i++
 				}
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds JSON tags to fields missing them in `TestSuite`.

Signed-off-by: Eric Stroczynski <estroczy@redhat.com>