### PR TITLE
golangci-lint bump to 1.35.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILD_DATE_PATH := github.com/kudobuilder/kuttl/pkg/version.buildDate
 DATE_FMT := "%Y-%m-%dT%H:%M:%SZ"
 BUILD_DATE := $(shell date -u -d "@$SOURCE_DATE_EPOCH" "+${DATE_FMT}" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH}" "+${DATE_FMT}" 2>/dev/null || date -u "+${DATE_FMT}")
 LDFLAGS := -X ${GIT_VERSION_PATH}=${GIT_VERSION} -X ${GIT_COMMIT_PATH}=${GIT_COMMIT} -X ${BUILD_DATE_PATH}=${BUILD_DATE}
-GOLANGCI_LINT_VER = "1.33.0"
+GOLANGCI_LINT_VER = "1.35.2"
 
 export GO111MODULE=on
 


### PR DESCRIPTION
Signed-off-by: Ken Sipe <kensipe@gmail.com>
