### PR TITLE
Support multiple Kubernetes clusters by supporting kubeconfig in test steps

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -99,6 +99,9 @@ type TestStep struct {
 
 	// Allowed environment labels
 	// Disallowed environment labels
+
+	// Kubeconfig to use when applying and asserting for this step.
+	Kubeconfig string `json:"kubeconfig,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/kudobuilder/kuttl/pkg/report"
 	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
 )
@@ -53,18 +55,13 @@ type namespace struct {
 }
 
 // DeleteNamespace deletes a namespace in Kubernetes after we are done using it.
-func (t *Case) DeleteNamespace(ns *namespace) error {
+func (t *Case) DeleteNamespace(cl client.Client, ns *namespace) error {
 	if !ns.AutoCreated {
 		t.Logger.Log("Skipping deletion of user-supplied namespace:", ns.Name)
 		return nil
 	}
 
 	t.Logger.Log("Deleting namespace:", ns.Name)
-
-	cl, err := t.Client(false)
-	if err != nil {
-		return err
-	}
 
 	ctx := context.Background()
 	if t.Timeout > 0 {
@@ -84,17 +81,12 @@ func (t *Case) DeleteNamespace(ns *namespace) error {
 }
 
 // CreateNamespace creates a namespace in Kubernetes to use for a test.
-func (t *Case) CreateNamespace(ns *namespace) error {
+func (t *Case) CreateNamespace(cl client.Client, ns *namespace) error {
 	if !ns.AutoCreated {
 		t.Logger.Log("Skipping creation of user-supplied namespace:", ns.Name)
 		return nil
 	}
 	t.Logger.Log("Creating namespace:", ns.Name)
-
-	cl, err := t.Client(false)
-	if err != nil {
-		return err
-	}
 
 	ctx := context.Background()
 	if t.Timeout > 0 {
@@ -196,22 +188,55 @@ func shortString(obj *corev1.ObjectReference) string {
 // Run runs a test case including all of its steps.
 func (t *Case) Run(test *testing.T, tc *report.Testcase) {
 	ns := t.determineNamespace()
-	if err := t.CreateNamespace(ns); err != nil {
+
+	cl, err := t.Client(false)
+	if err != nil {
 		tc.Failure = report.NewFailure(err.Error(), nil)
 		test.Fatal(err)
 	}
 
+	clients := map[string]client.Client{"": cl}
+
+	for _, testStep := range t.Steps {
+		if clients[testStep.Kubeconfig] != nil {
+			continue
+		}
+
+		cl, err := newClient(testStep.Kubeconfig)(false)
+		if err != nil {
+			tc.Failure = report.NewFailure(err.Error(), nil)
+			test.Fatal(err)
+		}
+
+		clients[testStep.Kubeconfig] = cl
+	}
+
+	for _, client := range clients {
+		if err := t.CreateNamespace(client, ns); err != nil {
+			tc.Failure = report.NewFailure(err.Error(), nil)
+			test.Fatal(err)
+		}
+	}
+
 	if !t.SkipDelete {
 		defer func() {
-			if err := t.DeleteNamespace(ns); err != nil {
-				test.Error(err)
+			for _, client := range clients {
+				if err := t.DeleteNamespace(client, ns); err != nil {
+					test.Error(err)
+				}
 			}
 		}()
 	}
 
 	for _, testStep := range t.Steps {
 		testStep.Client = t.Client
+		if testStep.Kubeconfig != "" {
+			testStep.Client = newClient(testStep.Kubeconfig)
+		}
 		testStep.DiscoveryClient = t.DiscoveryClient
+		if testStep.Kubeconfig != "" {
+			testStep.DiscoveryClient = newDiscoveryClient(testStep.Kubeconfig)
+		}
 		testStep.Logger = t.Logger.WithPrefix(testStep.String())
 		tc.Assertions += len(testStep.Asserts)
 		tc.Assertions += len(testStep.Errors)
@@ -348,4 +373,28 @@ func (t *Case) LoadTestSteps() error {
 
 	t.Steps = testSteps
 	return nil
+}
+
+func newClient(kubeconfig string) func(bool) (client.Client, error) {
+	return func(bool) (client.Client, error) {
+		config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+
+		return testutils.NewRetryClient(config, client.Options{
+			Scheme: testutils.Scheme(),
+		})
+	}
+}
+
+func newDiscoveryClient(kubeconfig string) func() (discovery.DiscoveryInterface, error) {
+	return func() (discovery.DiscoveryInterface, error) {
+		config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+
+		return discovery.NewDiscoveryClientForConfig(config)
+	}
 }

--- a/pkg/test/case_integration_test.go
+++ b/pkg/test/case_integration_test.go
@@ -1,0 +1,106 @@
+// +build integration
+
+package test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/kudobuilder/kuttl/pkg/report"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
+)
+
+// Create two test environments, ensure that the second environment is used when
+// Kubeconfig is set on a Step.
+func TestMultiClusterCase(t *testing.T) {
+	testenv, err := testutils.StartTestEnvironment(testutils.APIServerDefaultArgs, false)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer testenv.Environment.Stop()
+
+	testenv2, err := testutils.StartTestEnvironment(testutils.APIServerDefaultArgs, false)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer testenv2.Environment.Stop()
+
+	podSpec := map[string]interface{}{
+		"restartPolicy": "Never",
+		"containers": []map[string]interface{}{
+			{
+				"name":  "nginx",
+				"image": "nginx:1.7.9",
+			},
+		},
+	}
+
+	tmpfile, err := ioutil.TempFile("", "kubeconfig")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer os.Remove(tmpfile.Name())
+	if err := testutils.Kubeconfig(testenv2.Config, tmpfile); err != nil {
+		t.Error(err)
+		return
+	}
+
+	c := Case{
+		Logger: testutils.NewTestLogger(t, ""),
+		Steps: []*Step{
+			&Step{
+				Name:  "initialize-testenv",
+				Index: 0,
+				Apply: []runtime.Object{
+					testutils.WithSpec(t, testutils.NewPod("hello", ""), podSpec),
+				},
+				Asserts: []runtime.Object{
+					testutils.WithSpec(t, testutils.NewPod("hello", ""), podSpec),
+				},
+				Timeout: 2,
+			},
+			&Step{
+				Name:  "use-testenv2",
+				Index: 1,
+				Apply: []runtime.Object{
+					testutils.WithSpec(t, testutils.NewPod("hello2", ""), podSpec),
+				},
+				Asserts: []runtime.Object{
+					testutils.WithSpec(t, testutils.NewPod("hello2", ""), podSpec),
+				},
+				Errors: []runtime.Object{
+					testutils.WithSpec(t, testutils.NewPod("hello", ""), podSpec),
+				},
+				Timeout:    2,
+				Kubeconfig: tmpfile.Name(),
+			},
+			&Step{
+				Name:  "verify-testenv-does-not-have-testenv2-resources",
+				Index: 2,
+				Asserts: []runtime.Object{
+					testutils.WithSpec(t, testutils.NewPod("hello", ""), podSpec),
+				},
+				Errors: []runtime.Object{
+					testutils.WithSpec(t, testutils.NewPod("hello2", ""), podSpec),
+				},
+				Timeout: 2,
+			},
+		},
+		Client: func(bool) (client.Client, error) {
+			return testenv.Client, nil
+		},
+		DiscoveryClient: func() (discovery.DiscoveryInterface, error) {
+			return testenv.DiscoveryClient, nil
+		},
+	}
+
+	c.Run(t, &report.Testcase{})
+}

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -485,7 +485,7 @@ func (h *Harness) Setup() {
 			h.fatal(fmt.Errorf("fatal error installing manifests: %v", err))
 		}
 	}
-	bgs, err := testutils.RunCommands(h.GetLogger(), "default", h.TestSuite.Commands, "", h.TestSuite.Timeout)
+	bgs, err := testutils.RunCommands(h.GetLogger(), "default", h.TestSuite.Commands, "", h.TestSuite.Timeout, "")
 	// assign any background processes first for cleanup in case of any errors
 	h.bgProcesses = append(h.bgProcesses, bgs...)
 	if err != nil {

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -44,6 +44,7 @@ type Step struct {
 
 	Timeout int
 
+	Kubeconfig      string
 	Client          func(forceNew bool) (client.Client, error)
 	DiscoveryClient func() (discovery.DiscoveryInterface, error)
 
@@ -391,7 +392,7 @@ func (s *Step) Run(namespace string) []error {
 				command.Background = false
 			}
 		}
-		if _, err := testutils.RunCommands(s.Logger, namespace, s.Step.Commands, s.Dir, s.Timeout); err != nil {
+		if _, err := testutils.RunCommands(s.Logger, namespace, s.Step.Commands, s.Dir, s.Timeout, s.Kubeconfig); err != nil {
 			testErrors = append(testErrors, err)
 		}
 	}
@@ -428,7 +429,7 @@ func (s *Step) Run(namespace string) []error {
 			s.Logger.Log("skipping invalid assertion collector")
 			continue
 		}
-		_, err := testutils.RunCommand(context.TODO(), namespace, *collector.Command(), s.Dir, s.Logger, s.Logger, s.Logger, s.Timeout)
+		_, err := testutils.RunCommand(context.TODO(), namespace, *collector.Command(), s.Dir, s.Logger, s.Logger, s.Logger, s.Timeout, s.Kubeconfig)
 		if err != nil {
 			s.Logger.Log("post assert collector failure: %s", err)
 		}
@@ -489,6 +490,9 @@ func (s *Step) LoadYAML(file string) error {
 			s.Step.Index = s.Index
 			if s.Step.Name != "" {
 				s.Name = s.Step.Name
+			}
+			if s.Step.Kubeconfig != "" {
+				s.Kubeconfig = s.Step.Kubeconfig
 			}
 		} else {
 			applies = append(applies, obj)

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -121,7 +121,7 @@ func TestRunCommand(t *testing.T) {
 
 	logger := NewTestLogger(t, "")
 	// assert foreground cmd returns nil
-	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0)
+	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0, "")
 	assert.NoError(t, err)
 	assert.Nil(t, cmd)
 	// foreground processes should have stdout
@@ -131,7 +131,7 @@ func TestRunCommand(t *testing.T) {
 	stdout = &bytes.Buffer{}
 
 	// assert background cmd returns process
-	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, cmd)
 	// no stdout for background processes
@@ -142,7 +142,7 @@ func TestRunCommand(t *testing.T) {
 	hcmd.Command = "sleep 42"
 
 	// assert foreground cmd times out
-	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 2)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 2, "")
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "timeout"))
 	assert.Nil(t, cmd)
@@ -153,7 +153,7 @@ func TestRunCommand(t *testing.T) {
 	hcmd.Timeout = 2
 
 	// assert foreground cmd times out with command timeout
-	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0, "")
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "timeout"))
 	assert.Nil(t, cmd)
@@ -170,12 +170,12 @@ func TestRunCommandIgnoreErrors(t *testing.T) {
 
 	logger := NewTestLogger(t, "")
 	// assert foreground cmd returns nil
-	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0)
+	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0, "")
 	assert.NoError(t, err)
 	assert.Nil(t, cmd)
 
 	hcmd.IgnoreFailure = false
-	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0, "")
 	assert.Error(t, err)
 	assert.Nil(t, cmd)
 
@@ -184,7 +184,7 @@ func TestRunCommandIgnoreErrors(t *testing.T) {
 		Command:       "bad-command",
 		IgnoreFailure: true,
 	}
-	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0, "")
 	assert.Error(t, err)
 	assert.Nil(t, cmd)
 }
@@ -198,7 +198,7 @@ func TestRunCommandSkipLogOutput(t *testing.T) {
 
 	logger := NewTestLogger(t, "")
 	// test there is a stdout
-	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0)
+	cmd, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0, "")
 	assert.NoError(t, err)
 	assert.Nil(t, cmd)
 	assert.True(t, stdout.Len() > 0)
@@ -207,7 +207,7 @@ func TestRunCommandSkipLogOutput(t *testing.T) {
 	stdout = &bytes.Buffer{}
 	stderr = &bytes.Buffer{}
 	// test there is no stdout
-	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0)
+	cmd, err = RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0, "")
 	assert.NoError(t, err)
 	assert.Nil(t, cmd)
 	assert.True(t, stdout.Len() == 0)

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -480,7 +480,7 @@ func TestRunScript(t *testing.T) {
 
 			logger := NewTestLogger(t, "")
 			// script runs with output
-			_, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0)
+			_, err := RunCommand(context.TODO(), "", hcmd, "", stdout, stderr, logger, 0, "")
 
 			if tt.wantedErr {
 				assert.Error(t, err)


### PR DESCRIPTION
Adds a `kubeconfig` setting to the TestStep API allowing an alternative
kubeconfig path to be used for asserts, errors, commands and applies in a test step.

Implements KEP-0008 (#261)

Signed-off-by: jbarrick@mesosphere.com <jbarrick@mesosphere.com>