### PR TITLE
KEP 07 Implementation

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -111,6 +111,22 @@ type TestAssert struct {
 	Timeout int `json:"timeout"`
 	// Collectors is a set of pod log collectors fired on an assert failure
 	Collectors []*TestCollector `json:"collectors,omitempty"`
+	// Commands is a set of commands to be run as assertions for the current step
+	Commands []TestAssertCommand `json:"commands,omitempty"`
+}
+
+// TestAssertCommand an assertion based on the result of the execution of a command
+type TestAssertCommand struct {
+	// The command and argument to run as a string.
+	Command string `json:"command"`
+	// If set, the `--namespace` flag will be appended to the command with the namespace to use.
+	Namespaced bool `json:"namespaced"`
+	// Ability to run a shell script from TestStep (without a script file)
+	// namespaced and command should not be used with script.  namespaced is ignored and command is an error.
+	// env expansion is depended upon the shell but ENV is passed to the runtime env.
+	Script string `json:"script"`
+	// If set, the output from the command is NOT logged.  Useful for sensitive logs or to reduce noise.
+	SkipLogOutput bool `json:"skipLogOutput"`
 }
 
 // ObjectReference is a Kubernetes object reference with added labels to allow referencing

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -495,7 +495,7 @@ func (h *Harness) Setup() {
 			h.fatal(fmt.Errorf("fatal error installing manifests: %v", err))
 		}
 	}
-	bgs, err := testutils.RunCommands(h.GetLogger(), "default", h.TestSuite.Commands, "", h.TestSuite.Timeout)
+	bgs, err := testutils.RunCommands(context.TODO(), h.GetLogger(), "default", h.TestSuite.Commands, "", h.TestSuite.Timeout)
 	// assign any background processes first for cleanup in case of any errors
 	h.bgProcesses = append(h.bgProcesses, bgs...)
 	if err != nil {

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -356,11 +356,11 @@ func (s *Step) CheckResourceAbsent(expected runtime.Object, namespace string) er
 	return nil
 }
 
-// CheckAssertCommands checks if the commands defined in TestAsserts have been run successfully
+// CheckAssertCommands Runs the commands provided in `commands` and check if have been run successfully.
 // the errors returned can be a a failure of executing the command or the failure of the command executed.
-func (s *Step) CheckAssertCommands(ctx context.Context, namespace string, command []harness.TestAssertCommand, timeout int) []error {
+func (s *Step) CheckAssertCommands(ctx context.Context, namespace string, commands []harness.TestAssertCommand, timeout int) []error {
 	testErrors := []error{}
-	if _, err := testutils.RunAssertCommands(ctx, s.Logger, namespace, command, "", timeout); err != nil {
+	if _, err := testutils.RunAssertCommands(ctx, s.Logger, namespace, commands, "", timeout); err != nil {
 		testErrors = append(testErrors, err)
 	}
 	return testErrors

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -425,3 +425,100 @@ func TestStepFailure(t *testing.T) {
 	errs := step.Run(namespace)
 	assert.Equal(t, len(errs), 1)
 }
+
+func TestAssertCommandsValidCommandRunsOk(t *testing.T) {
+	
+	step := &Step{
+		Name:  			"commandRun",
+		Index: 			0,
+		Logger:          testutils.NewTestLogger(t, ""),
+		Client:          func(bool) (client.Client, error) { return testenv.Client, nil },
+		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testenv.DiscoveryClient, nil },
+	}
+
+	// Load test that has an echo command, so it should run ok, and don't return any errors
+	err := step.LoadYAML("step_integration_test_data/assert_commands/valid_command/00-assert.yaml")
+	assert.NoError(t, err)
+
+	errors := step.Run("irrelevant")
+	assert.Equal(t, len(errors), 0)
+}
+
+func TestAssertCommandsMultipleCommandRunsOk(t *testing.T) {
+	
+	step := &Step{
+		Name:  			"commandRun",
+		Index: 			0,
+		Logger:          testutils.NewTestLogger(t, ""),
+		Client:          func(bool) (client.Client, error) { return testenv.Client, nil },
+		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testenv.DiscoveryClient, nil },
+	}
+
+	// Load test that has an echo command, so it should run ok, and don't return any errors
+	err := step.LoadYAML("step_integration_test_data/assert_commands/multiple_commands/00-assert.yaml")
+	assert.NoError(t, err)
+
+	errors := step.Run("irrelevant")
+	assert.Equal(t, len(errors), 0)
+}
+
+func TestAssertCommandsMissingCommandFails(t *testing.T) {
+	
+	step := &Step{
+		Name:  			"commandRun",
+		Index: 			0,
+		Logger:          testutils.NewTestLogger(t, ""),
+		Client:          func(bool) (client.Client, error) { return testenv.Client, nil },
+		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testenv.DiscoveryClient, nil },
+	}
+
+	// Load test that has an command that is not present (thiscommanddoesnotexist), so it should return an error
+	err := step.LoadYAML("step_integration_test_data/assert_commands/command_does_not_exist/00-assert.yaml")
+	assert.NoError(t, err)
+
+	errors := step.Run("irrelevant")
+	assert.Equal(t, len(errors), 1)
+}
+
+func TestAssertCommandsFailingCommandFails(t *testing.T) {
+	
+	step := &Step{
+		Name:  			"commandRun",
+		Index: 			0,
+		Logger:          testutils.NewTestLogger(t, ""),
+		Client:          func(bool) (client.Client, error) { return testenv.Client, nil },
+		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testenv.DiscoveryClient, nil },
+	}
+
+	// Load test that has an command that is present but will allways fail (false), so we should get back the error.
+	err := step.LoadYAML("step_integration_test_data/assert_commands/failing_comand/00-assert.yaml")
+	assert.NoError(t, err)
+
+	errors := step.Run("irrelevant")
+	assert.Equal(t, len(errors), 1)
+}
+
+func TestAssertCommandsShouldTimeout(t *testing.T) {
+	
+	step := &Step{
+		Name:  			"commandRun",
+		Index: 			0,
+		Logger:          testutils.NewTestLogger(t, ""),
+		Client:          func(bool) (client.Client, error) { return testenv.Client, nil },
+		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testenv.DiscoveryClient, nil },
+	}
+
+	// Load test that has an command that sleeps for 5 seconds, while the timeout for the step is 2, 
+	// so we should get back the error, and the test should run in less slightly more than 2 seconds.
+	err := step.LoadYAML("step_integration_test_data/assert_commands/timingout_command/00-assert.yaml")
+	assert.NoError(t, err)
+
+	start := time.Now()
+	errors := step.Run("irrelevant")
+	duration := time.Since(start).Seconds()
+	assert.Greater(t, duration, float64(1))
+	assert.Less(t, duration, float64(5))
+	assert.Equal(t, len(errors), 1)
+}
+
+

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -427,10 +427,10 @@ func TestStepFailure(t *testing.T) {
 }
 
 func TestAssertCommandsValidCommandRunsOk(t *testing.T) {
-	
+
 	step := &Step{
-		Name:  			"commandRun",
-		Index: 			0,
+		Name:            t.Name(),
+		Index:           0,
 		Logger:          testutils.NewTestLogger(t, ""),
 		Client:          func(bool) (client.Client, error) { return testenv.Client, nil },
 		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testenv.DiscoveryClient, nil },
@@ -445,10 +445,10 @@ func TestAssertCommandsValidCommandRunsOk(t *testing.T) {
 }
 
 func TestAssertCommandsMultipleCommandRunsOk(t *testing.T) {
-	
+
 	step := &Step{
-		Name:  			"commandRun",
-		Index: 			0,
+		Name:            t.Name(),
+		Index:           0,
 		Logger:          testutils.NewTestLogger(t, ""),
 		Client:          func(bool) (client.Client, error) { return testenv.Client, nil },
 		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testenv.DiscoveryClient, nil },
@@ -463,10 +463,10 @@ func TestAssertCommandsMultipleCommandRunsOk(t *testing.T) {
 }
 
 func TestAssertCommandsMissingCommandFails(t *testing.T) {
-	
+
 	step := &Step{
-		Name:  			"commandRun",
-		Index: 			0,
+		Name:            t.Name(),
+		Index:           0,
 		Logger:          testutils.NewTestLogger(t, ""),
 		Client:          func(bool) (client.Client, error) { return testenv.Client, nil },
 		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testenv.DiscoveryClient, nil },
@@ -481,10 +481,10 @@ func TestAssertCommandsMissingCommandFails(t *testing.T) {
 }
 
 func TestAssertCommandsFailingCommandFails(t *testing.T) {
-	
+
 	step := &Step{
-		Name:  			"commandRun",
-		Index: 			0,
+		Name:            t.Name(),
+		Index:           0,
 		Logger:          testutils.NewTestLogger(t, ""),
 		Client:          func(bool) (client.Client, error) { return testenv.Client, nil },
 		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testenv.DiscoveryClient, nil },
@@ -499,17 +499,17 @@ func TestAssertCommandsFailingCommandFails(t *testing.T) {
 }
 
 func TestAssertCommandsShouldTimeout(t *testing.T) {
-	
+
 	step := &Step{
-		Name:  			"commandRun",
-		Index: 			0,
+		Name:            t.Name(),
+		Index:           0,
 		Logger:          testutils.NewTestLogger(t, ""),
 		Client:          func(bool) (client.Client, error) { return testenv.Client, nil },
 		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testenv.DiscoveryClient, nil },
 	}
 
-	// Load test that has an command that sleeps for 5 seconds, while the timeout for the step is 2, 
-	// so we should get back the error, and the test should run in less slightly more than 2 seconds.
+	// Load test that has an command that sleeps for 5 seconds, while the timeout for the step is 1,
+	// so we should get back the error, and the test should run in less slightly more than 1 seconds.
 	err := step.LoadYAML("step_integration_test_data/assert_commands/timingout_command/00-assert.yaml")
 	assert.NoError(t, err)
 
@@ -520,5 +520,3 @@ func TestAssertCommandsShouldTimeout(t *testing.T) {
 	assert.Less(t, duration, float64(5))
 	assert.Equal(t, len(errors), 1)
 }
-
-

--- a/pkg/test/step_integration_test_data/assert_commands/command_does_not_exist/00-assert.yaml
+++ b/pkg/test/step_integration_test_data/assert_commands/command_does_not_exist/00-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 1
+commands:
+  - command: thiscommanddoesnotexist

--- a/pkg/test/step_integration_test_data/assert_commands/failing_comand/00-assert.yaml
+++ b/pkg/test/step_integration_test_data/assert_commands/failing_comand/00-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 1
+commands:
+  - command: "false"

--- a/pkg/test/step_integration_test_data/assert_commands/multiple_commands/00-assert.yaml
+++ b/pkg/test/step_integration_test_data/assert_commands/multiple_commands/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 2
+commands:
+  - command: echo "first command"
+  - command: echo "second command"

--- a/pkg/test/step_integration_test_data/assert_commands/timingout_command/00-assert.yaml
+++ b/pkg/test/step_integration_test_data/assert_commands/timingout_command/00-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 1
+commands:
+  - command: sleep 5

--- a/pkg/test/step_integration_test_data/assert_commands/valid_command/00-assert.yaml
+++ b/pkg/test/step_integration_test_data/assert_commands/valid_command/00-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+commands:
+  - command: echo "this test works"

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1066,15 +1066,41 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 		return nil, nil
 	}
 	if errors.Is(cmdCtx.Err(), context.DeadlineExceeded) {
-		return nil, fmt.Errorf("command %q exceeded %v sec timeout", cmd.Command, timeout)
+		return nil, fmt.Errorf("command %q exceeded %v sec timeout, %w", cmd.Command, timeout, cmdCtx.Err())
 	}
 	return nil, err
+}
+
+// convertAssertCommand converts a set of TestAssertCommand to Commands so it all the existing functions can be used
+// that expect Commands data type.
+func convertAssertCommand(assertCommands []harness.TestAssertCommand, timeout int) (commands []harness.Command) {
+	commands = make([]harness.Command, 0, len(assertCommands))
+
+	for _, assertCommand := range assertCommands {
+		commands = append(commands, harness.Command{
+			Command:       assertCommand.Command,
+			Namespaced:    assertCommand.Namespaced,
+			Script:        assertCommand.Script,
+			SkipLogOutput: assertCommand.SkipLogOutput,
+			Timeout:       timeout,
+			// This fields will always be this constants for assertions
+			IgnoreFailure: false,
+			Background:    false,
+		})
+	}
+
+	return commands
+}
+
+// RunAssertCommands runs a set of commands specified as TestAssertCommand
+func RunAssertCommands(ctx context.Context, logger Logger, namespace string, commands []harness.TestAssertCommand, workdir string, timeout int) ([]*exec.Cmd, error) {
+	return RunCommands(ctx, logger, namespace, convertAssertCommand(commands, timeout), workdir, timeout)
 }
 
 // RunCommands runs a set of commands, returning any errors.
 // If any (non-background) command fails, the following commands are skipped
 // commands running in the background are returned
-func RunCommands(logger Logger, namespace string, commands []harness.Command, workdir string, timeout int) ([]*exec.Cmd, error) {
+func RunCommands(ctx context.Context, logger Logger, namespace string, commands []harness.Command, workdir string, timeout int) ([]*exec.Cmd, error) {
 	bgs := []*exec.Cmd{}
 
 	if commands == nil {
@@ -1083,7 +1109,7 @@ func RunCommands(logger Logger, namespace string, commands []harness.Command, wo
 
 	for i, cmd := range commands {
 
-		bg, err := RunCommand(context.Background(), namespace, cmd, workdir, logger, logger, logger, timeout)
+		bg, err := RunCommand(ctx, namespace, cmd, workdir, logger, logger, logger, timeout)
 		if err != nil {
 			cmdListSize := len(commands)
 			if i+1 < cmdListSize {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This implements KEP 07 (Draft) by appending the AssertCommands to the TestStep structure.

```go
type TestAssertCommand struct {
	// The command and argument to run as a string.
	Command string `json:"command"`
	// If set, the `--namespace` flag will be appended to the command with the namespace to use.
	Namespaced bool `json:"namespaced"`
	// Ability to run a shell script from TestStep (without a script file)
	// namespaced and command should not be used with script.  namespaced is ignored and command is an error.
	// env expansion is depended upon the shell but ENV is passed to the runtime env.
	Script string `json:"script"`
	// If set, the output from the command is NOT logged.  Useful for sensitive logs or to reduce noise.
	SkipLogOutput bool `json:"skipLogOutput"`
}
```

There's no issue associated with KEP 07.


> Create TestAssertCommand struct, and add it as a list to TestAssert
> Create Helper functions in utils to run assertions'
> Update RunCommands to receive an existing context
> Update step Check method to also run the scripts/commands specified in the step assertion
> Update the set Run command to honor the timeout (as commands can be lengthy)