### PR TITLE
Alternative ServiceAccount check

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -270,7 +270,17 @@ func (h *Harness) Config() (*rest.Config, error) {
 		// we avoid this with "inCluster" as the cluster must be already be up since we're running on it
 		err = testutils.WaitForSA(h.config, "default", "default")
 		if err != nil {
-			return h.config, err
+			// if there is a namespace provided but no "default"/"default" SA found, also check a SA in the provided NS
+			if h.TestSuite.Namespace != "" {
+				tempErr := testutils.WaitForSA(h.config, "default", h.TestSuite.Namespace)
+
+				// if it still does not have a SA then return the first "default"/"default" error
+				if tempErr != nil {
+					return h.config, err
+				}
+			} else {
+				return h.config, err
+			}
 		}
 		h.T.Logf("Successful connection to cluster at: %s", h.config.Host)
 	}


### PR DESCRIPTION
Hello :)

**What this PR does / why we need it**:

This PR provides a double check when looking for ServiceAccount. By default, it looks at SA "default" in "default" namespace and if it does not find it, it throws an error. Now with this PR when you use Kuttl for a "single/specified namespace" test and Kuttl cannot access default/default SA it will also look at "default" SA in the namespace provided.

It's useful when you have a cluster with high restriction policy based on namespace and have only access to the resources of your dedicated namespace.

This does not change the 'normal' behavior of Harness SA assertion.
 
Fixes #270 
