### PR TITLE
Linter now picks up integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ifneq (${GOLANGCI_LINT_VER}, "$(shell ./bin/golangci-lint version --format short
 	@echo "golangci-lint missing or not version '${GOLANGCI_LINT_VER}', downloading..."
 	curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/v${GOLANGCI_LINT_VER}/install.sh" | sh -s -- -b ./bin "v${GOLANGCI_LINT_VER}"
 endif
-	./bin/golangci-lint --timeout 3m run
+	./bin/golangci-lint --timeout 3m run --build-tags integration
 	
 .PHONY: download
 download:  ## Downloads go dependencies

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -231,6 +231,7 @@ func TestCheckResourceIntegration(t *testing.T) {
 			shouldError: true,
 		},
 	} {
+		test := test
 		t.Run(test.testName, func(t *testing.T) {
 			namespace := fmt.Sprintf("kuttl-test-%s", petname.Generate(2, "-"))
 
@@ -239,7 +240,6 @@ func TestCheckResourceIntegration(t *testing.T) {
 				// we are ignoring already exists here because in tests we by default use retry client so this can happen
 				assert.Nil(t, err)
 			}
-
 			for _, actual := range test.actual {
 				_, _, err := testutils.Namespaced(testenv.DiscoveryClient, actual, namespace)
 				assert.Nil(t, err)
@@ -332,6 +332,7 @@ func TestCheckedTypeAssertions(t *testing.T) {
 		{"apply", "TestStep"},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			step := Step{}
 			path := fmt.Sprintf("step_integration_test_data/error_detect/00-%s.yaml", test.name)
@@ -412,12 +413,6 @@ func TestStepFailure(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	//for _, actual := range test.actual {
-	//	_, _, err := testutils.Namespaced(testenv.DiscoveryClient, actual, namespace)
-	//	assert.Nil(t, err)
-	//
-	//	assert.Nil(t, testenv.Client.Create(context.TODO(), actual))
-	//}
 	asserts := []runtime.Object{expected}
 	step := Step{
 		Logger:          testutils.NewTestLogger(t, ""),

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -97,17 +97,17 @@ func TestClientWatch(t *testing.T) {
 	event := <-eventCh
 	assert.Equal(t, watch.EventType("ADDED"), event.Type)
 	assert.Equal(t, gvk, event.Object.GetObjectKind().GroupVersionKind())
-	assert.Equal(t, client.ObjectKey{"default", "my-pod"}, ObjectKey(event.Object))
+	assert.Equal(t, client.ObjectKey{Namespace: "default", Name: "my-pod"}, ObjectKey(event.Object))
 
 	event = <-eventCh
 	assert.Equal(t, watch.EventType("MODIFIED"), event.Type)
 	assert.Equal(t, gvk, event.Object.GetObjectKind().GroupVersionKind())
-	assert.Equal(t, client.ObjectKey{"default", "my-pod"}, ObjectKey(event.Object))
+	assert.Equal(t, client.ObjectKey{Namespace: "default", Name: "my-pod"}, ObjectKey(event.Object))
 
 	event = <-eventCh
 	assert.Equal(t, watch.EventType("DELETED"), event.Type)
 	assert.Equal(t, gvk, event.Object.GetObjectKind().GroupVersionKind())
-	assert.Equal(t, client.ObjectKey{"default", "my-pod"}, ObjectKey(event.Object))
+	assert.Equal(t, client.ObjectKey{Namespace: "default", Name: "my-pod"}, ObjectKey(event.Object))
 
 	events.Stop()
 }


### PR DESCRIPTION
Signed-off-by: Ken Sipe <kensipe@gmail.com>

The linter was not linter for the integration build tag.   It was noticed when unaligned integration test code was added by PR #272 .   Fixed here which required additional clean up.