### PR TITLE
Add tar and gzip to the image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN make cli
 # release image with kubectl + kuttl
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN microdnf install vim
+RUN microdnf install vim tar gzip
 RUN echo 'alias vi=vim' >> ~/.bashrc
 
 #  kube 1.18


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `tar` and `gzip` utilities to the kuttl image, so users could run installation scripts for other tools (e.g., https://helm.sh/docs/intro/install/#from-script) needed in their tests.


Follow-up question: is it necessary to have `vim` in the image?