### PR TITLE
changes to the 1.16 testing libraries

### DIFF
--- a/pkg/test/utils/testing.go
+++ b/pkg/test/utils/testing.go
@@ -66,6 +66,8 @@ func (testDeps) MatchString(pat, str string) (result bool, err error) {
 	return matchRe.MatchString(str), nil
 }
 
+func (testDeps) SetPanicOnExit0(bool) {}
+
 func (testDeps) StartCPUProfile(w io.Writer) error {
 	return pprof.StartCPUProfile(w)
 }


### PR DESCRIPTION
Apparently changes to go test do NOT need to be backward compatible :)   comments in code:

```
// It is not meant to be called directly and is not subject to the Go 1 compatibility document.
```
ref:  https://golang.org/src/testing/testing.go

This change is safe to merge allowing kuttl to be built with go 1.15 or go 1.16 (1.16 fails without it)

Signed-off-by: Ken Sipe <kensipe@gmail.com>

