### PR TITLE
Flush command log always

### DIFF
--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -460,9 +460,7 @@ func (s *Step) Run(namespace string) []error {
 			s.Logger.Log("post assert collector failure: %s", err)
 		}
 	}
-	if len(s.Assert.Collectors) > 0 {
-		s.Logger.Flush()
-	}
+	s.Logger.Flush()
 	return testErrors
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Currently, we flush only if ANY collector is specified. I think it would make more sense to flush always. If we take a look at how is the step logger used, there are logs like "starting to process step" or the actual output of the assert command. I don't think this should be linked to specifying collector if I don't want any other logs collected.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #287
