### PR TITLE
fix: handle kubeconfig path resolution in steps properly

### DIFF
--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -356,6 +356,22 @@ func TestApplyExpansion(t *testing.T) {
 
 }
 
+func TestOverriddenKubeconfigPathResolution(t *testing.T) {
+	os.Setenv("SUBPATH", "test")
+	defer func() {
+		os.Unsetenv("SUBPATH")
+	}()
+	stepRelativePath := &Step{Dir: "step_integration_test_data/kubeconfig_path_resolution/"}
+	err := stepRelativePath.LoadYAML("step_integration_test_data/kubeconfig_path_resolution/00-step1.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "step_integration_test_data/kubeconfig_path_resolution/kubeconfig-test.yaml", stepRelativePath.Kubeconfig)
+
+	stepAbsPath := &Step{Dir: "step_integration_test_data/kubeconfig_path_resolution/"}
+	err = stepAbsPath.LoadYAML("step_integration_test_data/kubeconfig_path_resolution/00-step2.yaml")
+	assert.NoError(t, err)
+	assert.Equal(t, "/absolute/kubeconfig-test.yaml", stepAbsPath.Kubeconfig)
+}
+
 func TestTwoTestStepping(t *testing.T) {
 	apply := []client.Object{}
 	step := &Step{

--- a/pkg/test/step_integration_test_data/kubeconfig_path_resolution/00-step1.yaml
+++ b/pkg/test/step_integration_test_data/kubeconfig_path_resolution/00-step1.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+kubeconfig: ./kubeconfig-${SUBPATH}.yaml
+timeout: 30

--- a/pkg/test/step_integration_test_data/kubeconfig_path_resolution/00-step2.yaml
+++ b/pkg/test/step_integration_test_data/kubeconfig_path_resolution/00-step2.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+kubeconfig: /absolute/kubeconfig-${SUBPATH}.yaml
+timeout: 30

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1016,7 +1016,11 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 	kuttlENV["NAMESPACE"] = namespace
 	kuttlENV["KUBECONFIG"] = fmt.Sprintf("%s/kubeconfig", actualDir)
 	if kubeconfigOverride != "" {
-		kuttlENV["KUBECONFIG"] = filepath.Join(actualDir, kubeconfigOverride)
+		if filepath.IsAbs(kubeconfigOverride) {
+			kuttlENV["KUBECONFIG"] = kubeconfigOverride
+		} else {
+			kuttlENV["KUBECONFIG"] = filepath.Join(actualDir, kubeconfigOverride)
+		}
 	}
 	kuttlENV["PATH"] = fmt.Sprintf("%s/bin/:%s", actualDir, os.Getenv("PATH"))
 

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1014,14 +1014,7 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 
 	kuttlENV := make(map[string]string)
 	kuttlENV["NAMESPACE"] = namespace
-	kuttlENV["KUBECONFIG"] = fmt.Sprintf("%s/kubeconfig", actualDir)
-	if kubeconfigOverride != "" {
-		if filepath.IsAbs(kubeconfigOverride) {
-			kuttlENV["KUBECONFIG"] = kubeconfigOverride
-		} else {
-			kuttlENV["KUBECONFIG"] = filepath.Join(actualDir, kubeconfigOverride)
-		}
-	}
+	kuttlENV["KUBECONFIG"] = kubeconfigPath(actualDir, kubeconfigOverride)
 	kuttlENV["PATH"] = fmt.Sprintf("%s/bin/:%s", actualDir, os.Getenv("PATH"))
 
 	// by default testsuite timeout is the command timeout
@@ -1085,6 +1078,16 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 		return nil, fmt.Errorf("command %q exceeded %v sec timeout, %w", cmd.Command, timeout, cmdCtx.Err())
 	}
 	return nil, err
+}
+
+func kubeconfigPath(actualDir, override string) string {
+	if override != "" {
+		if filepath.IsAbs(override) {
+			return override
+		}
+		return filepath.Join(actualDir, override)
+	}
+	return fmt.Sprintf("%s/kubeconfig", actualDir)
 }
 
 // convertAssertCommand converts a set of TestAssertCommand to Commands so it all the existing functions can be used

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -120,6 +120,28 @@ func TestRetryWithUnexpectedError(t *testing.T) {
 	assert.Equal(t, 1, index)
 }
 
+func TestKubeconfigPath(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		path     string
+		override string
+		expected string
+	}{
+		{name: "no-override", path: "foo", expected: "foo/kubeconfig"},
+		{name: "override-relative", path: "foo", override: "bar/kubeconfig", expected: "foo/bar/kubeconfig"},
+		{name: "override-abs", path: "foo", override: "/bar/kubeconfig", expected: "/bar/kubeconfig"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			result := kubeconfigPath(tt.path, tt.override)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestRetryWithNil(t *testing.T) {
 	assert.Equal(t, nil, Retry(context.TODO(), nil, IsJSONSyntaxError))
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

When specifying absolute paths for kubeconfig in test spec, the `kubeconfig` field is [cleaned first (relative path is expanded and converted to absolute path)](https://github.com/kudobuilder/kuttl/blob/fc8c0f2b2f338dc39de1ff346077eee175ed4172/pkg/test/step.go#L521) and then that path is prepended again (irrespective of it being an absolute or relative path). 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #302 
