### PR TITLE
Bump golangci-lint to 1.41.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,18 +4,18 @@ linters:
     - deadcode
     - dupl
     - errcheck
+    - exportloopref
     - goconst
     - gocritic
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - gosimple
     - ineffassign
     - lll
     - misspell
     - nakedret
-    - scopelint
+    - revive
     - staticcheck
     - structcheck
     - stylecheck

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILD_DATE_PATH := github.com/kudobuilder/kuttl/pkg/version.buildDate
 DATE_FMT := "%Y-%m-%dT%H:%M:%SZ"
 BUILD_DATE := $(shell date -u -d "@$SOURCE_DATE_EPOCH" "+${DATE_FMT}" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH}" "+${DATE_FMT}" 2>/dev/null || date -u "+${DATE_FMT}")
 LDFLAGS := -X ${GIT_VERSION_PATH}=${GIT_VERSION} -X ${GIT_COMMIT_PATH}=${GIT_COMMIT} -X ${BUILD_DATE_PATH}=${BUILD_DATE}
-GOLANGCI_LINT_VER = "1.38.0"
+GOLANGCI_LINT_VER = "1.41.1"
 
 export GO111MODULE=on
 

--- a/pkg/test/kind.go
+++ b/pkg/test/kind.go
@@ -101,11 +101,7 @@ func loadContainer(docker testutils.DockerClient, node nodes.Node, container str
 
 	defer image.Close()
 
-	if err := nodeutils.LoadImageArchive(node, image); err != nil {
-		return err
-	}
-
-	return nil
+	return nodeutils.LoadImageArchive(node, image)
 }
 
 // IsMinVersion checks if pass ver is the min required kind version


### PR DESCRIPTION
This was more than expected :) 

* Bump of golangci-lint to 1.41.1
* Resulted in depreciation warnings with replacements.  Switched to replacement linters.
* Resulted in a redundant error change which is resolved in this PR

Signed-off-by: Ken Sipe <kensipe@gmail.com>

