### PR TITLE
Adding log message for error caught by linter

### DIFF
--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	petname "github.com/dustinkirkland/golang-petname"
-	funk "github.com/thoas/go-funk"
+	"github.com/thoas/go-funk"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	eventsbeta1 "k8s.io/api/events/v1beta1"
@@ -173,6 +173,9 @@ func (t *Case) CollectEvents(namespace string) {
 		if err != nil {
 			t.Logger.Log("Trying with events corev1 API...")
 			err = t.collectEventsCoreV1(cl, namespace)
+			if err != nil {
+				t.Logger.Log("All event APIs failed")
+			}
 		}
 	}
 }


### PR DESCRIPTION
Code for https://github.com/kudobuilder/kuttl/pull/299 caused a lint failure on main.  This was due to a change in linters after the PR was created.   This solve the lint issue.

Signed-off-by: Ken Sipe <kensipe@gmail.com>
