### PR TITLE
Adding Darwin M1 Chip Support to Krew

### DIFF
--- a/hack/generate_krew.sh
+++ b/hack/generate_krew.sh
@@ -69,6 +69,7 @@ EOF
 generate_platform linux amd64 ./kubectl-kuttl >> kuttl.yaml
 generate_platform linux 386 ./kubectl-kuttl >> kuttl.yaml
 generate_platform darwin amd64 ./kubectl-kuttl >> kuttl.yaml
+generate_platform darwin arm64 ./kubectl-kuttl >> kuttl.yaml
 
 ### Discontinued support for 32-bit darwin
 # generate_platform darwin 386 ./kubectl-kuttl >> kuttl.yaml


### PR DESCRIPTION
This was already used to update krew manifast and was accepted on https://github.com/kubernetes-sigs/krew-index/pull/1405

Signed-off-by: Ken Sipe <kensipe@gmail.com>

