### PR TITLE
KEP-7 Implmented

### DIFF
--- a/keps/0007-command-asserts.md
+++ b/keps/0007-command-asserts.md
@@ -8,8 +8,8 @@ owners:
   - "@nfnt"
   - "@kensipe"
 creation-date: 2020-10-28
-last-updated: 2021-02-04
-status: implementable
+last-updated: 2021-09-02
+status: implemented
 ---
 
 # Assertions for CLI commands


### PR DESCRIPTION
Signed-off-by: Ken Sipe <kensipe@gmail.com>

Replaces https://github.com/kudobuilder/kuttl/pull/276 which was a community attempt to close the kep
