### PR TITLE
Correct --config help string.

### DIFF
--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -233,7 +233,7 @@ For more detailed documentation, visit: https://kuttl.dev`,
 		},
 	}
 
-	testCmd.Flags().StringVar(&configPath, "config", "", "Path to file to load base test settings from (these may be overriden with command-line arguments).")
+	testCmd.Flags().StringVar(&configPath, "config", "", "Path to file to load base test settings from (these may be overridden with command-line arguments).")
 	testCmd.Flags().StringVar(&crdDir, "crd-dir", "", "Directory to load CustomResourceDefinitions from prior to running the tests.")
 	testCmd.Flags().StringSliceVar(&manifestDirs, "manifest-dir", []string{}, "One or more directories containing manifests to apply before running the tests.")
 	testCmd.Flags().StringVar(&testToRun, "test", "", "If set, the specific test case to run.")

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -233,7 +233,7 @@ For more detailed documentation, visit: https://kuttl.dev`,
 		},
 	}
 
-	testCmd.Flags().StringVar(&configPath, "config", "", "Path to file to load test settings from (must not be set with any other arguments).")
+	testCmd.Flags().StringVar(&configPath, "config", "", "Path to file to load base test settings from (these may be overriden with command-line arguments).")
 	testCmd.Flags().StringVar(&crdDir, "crd-dir", "", "Directory to load CustomResourceDefinitions from prior to running the tests.")
 	testCmd.Flags().StringSliceVar(&manifestDirs, "manifest-dir", []string{}, "One or more directories containing manifests to apply before running the tests.")
 	testCmd.Flags().StringVar(&testToRun, "test", "", "If set, the specific test case to run.")


### PR DESCRIPTION
**What this PR does / why we need it**:

For example running `kubectl-kuttl-0.11.0 test tests/upgrade` in a directory with `kuttl-test.yaml` does not return in an error. Instead it loads the config and then overrides the `testDirs` with the command line argument. This works regardless of whether an explicit `--config kuttl-test.yaml` is specified or not.
```
2021/09/09 09:42:02 kutt-test config testdirs is overridden with args: [ tests/upgrade ]
```
This is a common convention and quite useful.

