### PR TITLE
Do not hide YAML parsing errors.

### DIFF
--- a/pkg/file/files.go
+++ b/pkg/file/files.go
@@ -19,7 +19,7 @@ func ToObjects(paths []string) ([]client.Object, error) {
 	for _, path := range paths {
 		objs, err := testutils.LoadYAMLFromFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("file %q load yaml error", path)
+			return nil, fmt.Errorf("file %q load yaml error: %w", path, err)
 		}
 		apply = append(apply, objs...)
 	}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -28,7 +28,7 @@ func ToObjects(urlPath string) ([]client.Object, error) {
 
 	objs, err := testutils.LoadYAML(urlPath, buf)
 	if err != nil {
-		return nil, fmt.Errorf("url %q load yaml error", urlPath)
+		return nil, fmt.Errorf("url %q load yaml error: %w", urlPath, err)
 	}
 	apply = append(apply, objs...)
 


### PR DESCRIPTION
**What this PR does / why we need it**:


Before:
```
$ echo '"error' | ./bin/kubectl-kuttl assert /dev/stdin 
Error: file "/dev/stdin" load yaml error
$
```

After:
```
$ echo '"error' | ./bin/kubectl-kuttl assert /dev/stdin 
Error: file "/dev/stdin" load yaml error: error decoding yaml /dev/stdin: error converting YAML to JSON: yaml: line 2: found unexpected end of stream
$
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #323 
