### PR TITLE
Enable receiving a rest config on TestSuite

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -67,6 +68,8 @@ type TestSuite struct {
 	Namespace string `json:"namespace"`
 	// Suppress is used to suppress logs
 	Suppress []string `json:"suppress"`
+
+	Config *rest.Config `json:"config,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -238,6 +238,9 @@ func (h *Harness) Config() (*rest.Config, error) {
 
 	var err error
 	switch {
+	case h.TestSuite.Config != nil:
+		h.T.Log("running tests with passed rest config.")
+		h.config = h.TestSuite.Config
 	case h.TestSuite.StartControlPlane:
 		h.T.Log("running tests with a mocked control plane (kube-apiserver and etcd).")
 		h.config, err = h.RunTestEnv()

--- a/pkg/test/harness_integration_test.go
+++ b/pkg/test/harness_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	harness "github.com/kudobuilder/kuttl/pkg/apis/testharness/v1beta1"
+	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
 )
 
 func TestHarnessRunIntegration(t *testing.T) {
@@ -23,6 +24,29 @@ func TestHarnessRunIntegration(t *testing.T) {
 		T: t,
 	}
 	harness.Run()
+}
+
+func TestHarnessRunIntegrationWithConfig(t *testing.T) {
+	testenv, err := testutils.StartTestEnvironment(nil, false)
+	if err != nil {
+		t.Fatalf("fatal error starting environment: %s", err)
+	}
+	harness := Harness{
+		TestSuite: harness.TestSuite{
+			TestDirs: []string{
+				"./test_data/",
+			},
+			// set as true to skip service account check
+			StartControlPlane: true,
+			Config:            testenv.Config,
+			CRDDir:            "./test_crds/",
+		},
+		T: t,
+	}
+	harness.Run()
+	if err := testenv.Environment.Stop(); err != nil {
+		t.Log("error tearing down mock control plane", err)
+	}
 }
 
 // This test requires external KinD support to run thus is an integration test


### PR DESCRIPTION
Signed-off-by: Ali Felan <alifelan@google.com>

**What this PR does / why we need it**:
This adds an extra option to TestSuite, which allows KUTTL to run with a rest config, opening possibilities for customization on Go.

This is still missing testing and documentation, but wanted to share it to get feedback. My first try was making the config an exported name in harness, but that required a lot of changes in names (config to Config and Config() to GetConfig()). Adding it to TestSuite was easier, but it's the only non primitive type there.

Fixes #347
