### PR TITLE
Fix Report Failure on Skip Delete

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -538,6 +538,8 @@ func (h *Harness) Stop() {
 		}
 	}
 
+	h.Report()
+
 	if h.TestSuite.SkipClusterDelete {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -573,7 +575,6 @@ func (h *Harness) Stop() {
 
 		h.kind = nil
 	}
-	h.Report()
 }
 
 // wraps Test.Fatal in order to clean up harness


### PR DESCRIPTION
Build reports before cluster delete decisions

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes # 330. https://github.com/kudobuilder/kuttl/issues/330
