### PR TITLE
Test Report Dir Bug Fix

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -218,16 +218,11 @@ func latestEnd(start time.Time, testcases []*Testcase) time.Time {
 func (ts *Testsuites) Report(dir, name string, ftype Type) error {
 	ts.Close()
 
-	// Create the folder to save the report if it doesn't exist
-	_, err := os.Stat(dir)
-
-	if os.IsNotExist(err) {
-		err = os.MkdirAll(dir, 0755)
+	if dir != "" {
+		err := ensureDir(dir)
 		if err != nil {
 			return err
 		}
-	} else if err != nil {
-		return err
 	}
 
 	// if a report is requested it is always created
@@ -239,6 +234,19 @@ func (ts *Testsuites) Report(dir, name string, ftype Type) error {
 	default:
 		return writeJSONReport(dir, name, ts)
 	}
+}
+
+func ensureDir(dir string) error {
+	_, err := os.Stat(dir)
+	// TODO log this, need to passing logger or have logger added to Testsuites
+	// Create the folder to save the report if it doesn't exist
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(dir, 0755)
+		if err != nil {
+			return err
+		}
+	}
+	return err
 }
 
 // NewSuite creates and assigns a TestSuite to the TestSuites (then returns the suite)

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -242,9 +242,7 @@ func ensureDir(dir string) error {
 	// Create the folder to save the report if it doesn't exist
 	if os.IsNotExist(err) {
 		err = os.MkdirAll(dir, 0755)
-		if err != nil {
-			return err
-		}
+		//	no need for error check, it is always returned and handled by caller
 	}
 	return err
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -218,11 +218,9 @@ func latestEnd(start time.Time, testcases []*Testcase) time.Time {
 func (ts *Testsuites) Report(dir, name string, ftype Type) error {
 	ts.Close()
 
-	if dir != "" {
-		err := ensureDir(dir)
-		if err != nil {
-			return err
-		}
+	err := ensureDir(dir)
+	if err != nil {
+		return err
 	}
 
 	// if a report is requested it is always created
@@ -237,6 +235,9 @@ func (ts *Testsuites) Report(dir, name string, ftype Type) error {
 }
 
 func ensureDir(dir string) error {
+	if dir != "" {
+		return nil
+	}
 	_, err := os.Stat(dir)
 	// TODO log this, need to passing logger or have logger added to Testsuites
 	// Create the folder to save the report if it doesn't exist

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -235,7 +235,7 @@ func (ts *Testsuites) Report(dir, name string, ftype Type) error {
 }
 
 func ensureDir(dir string) error {
-	if dir != "" {
+	if dir == "" {
 		return nil
 	}
 	_, err := os.Stat(dir)


### PR DESCRIPTION
A newly added feature was to create the directory for test reports if it didn't exist.  The default if not specified location of the test report was "", which equated to the current directory.  The check on "" existence was false which lead to the `mkdir ""` which is obvious going to fail.   The solution is to verify that the artifactsDir isn't "" prior to that logic.

Thanks to the community Erik and @iblancasa  for helping discover and track down so quickly.  We will be getting a patch release out today. 

Signed-off-by: Ken Sipe <kensipe@gmail.com>

