### PR TITLE
golangci-lint bump to 1.49.0 along with required resolutions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 linters:
   auto-fix: false
   enable:
-    - deadcode
     - dupl
     - errcheck
     - exportloopref
@@ -17,12 +16,10 @@ linters:
     - nakedret
     - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
 run:
   go: '1.17'
   skip-dirs:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILD_DATE_PATH := github.com/kudobuilder/kuttl/pkg/version.buildDate
 DATE_FMT := "%Y-%m-%dT%H:%M:%SZ"
 BUILD_DATE := $(shell date -u -d "@$SOURCE_DATE_EPOCH" "+${DATE_FMT}" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH}" "+${DATE_FMT}" 2>/dev/null || date -u "+${DATE_FMT}")
 LDFLAGS := -X ${GIT_VERSION_PATH}=${GIT_VERSION} -X ${GIT_COMMIT_PATH}=${GIT_COMMIT} -X ${BUILD_DATE_PATH}=${BUILD_DATE}
-GOLANGCI_LINT_VER = "1.45.2"
+GOLANGCI_LINT_VER = "1.49.0"
 
 export GO111MODULE=on
 

--- a/pkg/file/files.go
+++ b/pkg/file/files.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,7 +40,7 @@ func FromPath(path, pattern string) ([]string, error) {
 		return nil, fmt.Errorf("file mode issue with %w", err)
 	}
 	if fi.IsDir() {
-		fileInfos, err := ioutil.ReadDir(path)
+		fileInfos, err := os.ReadDir(path)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -271,7 +270,7 @@ func writeXMLReport(dir, name string, ts *Testsuites) error {
 	}
 	xmlStr := string(xDoc)
 	//nolint:gosec
-	return ioutil.WriteFile(file, []byte(xmlStr), 0644)
+	return os.WriteFile(file, []byte(xmlStr), 0644)
 }
 
 func writeJSONReport(dir, name string, ts *Testsuites) error {
@@ -282,5 +281,5 @@ func writeJSONReport(dir, name string, ts *Testsuites) error {
 	}
 
 	//nolint:gosec
-	return ioutil.WriteFile(file, jDoc, 0644)
+	return os.WriteFile(file, jDoc, 0644)
 }

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"flag"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -67,19 +67,19 @@ AssertionError`,
 
 	if *updateGolden {
 		t.Logf("updating golden files %s and %s", goldenXML, goldenJSON)
-		if err := ioutil.WriteFile(xmlFile, []byte(xout), 0600); err != nil {
+		if err := os.WriteFile(xmlFile, []byte(xout), 0600); err != nil {
 			t.Fatalf("failed to update golden file: %s", err)
 		}
-		if err := ioutil.WriteFile(jsonFile, []byte(jout), 0600); err != nil {
+		if err := os.WriteFile(jsonFile, []byte(jout), 0600); err != nil {
 			t.Fatalf("failed to update golden file: %s", err)
 		}
 	}
-	gxml, err := ioutil.ReadFile(xmlFile)
+	gxml, err := os.ReadFile(xmlFile)
 	if err != nil {
 		t.Fatalf("failed reading .golden: %s", err)
 	}
 	assert.Equal(t, string(gxml), xout, "for golden file: %s", xmlFile)
-	gjson, err := ioutil.ReadFile(jsonFile)
+	gjson, err := os.ReadFile(jsonFile)
 	if err != nil {
 		t.Fatalf("failed reading .golden: %s", err)
 	}

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -3,7 +3,7 @@ package test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -392,7 +392,7 @@ func (t *Case) determineNamespace() *namespace {
 func (t *Case) CollectTestStepFiles() (map[int64][]string, error) {
 	testStepFiles := map[int64][]string{}
 
-	files, err := ioutil.ReadDir(t.Dir)
+	files, err := os.ReadDir(t.Dir)
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +414,7 @@ func (t *Case) CollectTestStepFiles() (map[int64][]string, error) {
 		testStepPath := filepath.Join(t.Dir, file.Name())
 
 		if file.IsDir() {
-			testStepDir, err := ioutil.ReadDir(testStepPath)
+			testStepDir, err := os.ReadDir(testStepPath)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/test/case_integration_test.go
+++ b/pkg/test/case_integration_test.go
@@ -3,7 +3,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -41,7 +40,7 @@ func TestMultiClusterCase(t *testing.T) {
 		},
 	}
 
-	tmpfile, err := ioutil.TempFile("", "kubeconfig")
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		t.Error(err)
 		return

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -63,7 +62,7 @@ func (h *Harness) LoadTests(dir string) ([]*Case, error) {
 		return nil, err
 	}
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +169,7 @@ func (h *Harness) RunKIND() (*rest.Config, error) {
 // various parts of system may need it, starting with kind, or working with tar test suites
 func (h *Harness) initTempPath() (err error) {
 	if h.tempPath == "" {
-		h.tempPath, err = ioutil.TempDir("", "kuttl")
+		h.tempPath, err = os.MkdirTemp("", "kuttl")
 		h.T.Log("temp folder created", h.tempPath)
 	}
 	return err
@@ -415,7 +414,7 @@ func (h *Harness) testPreProcessing() []string {
 			client := http.NewClient()
 			h.T.Logf("downloading %s", dir)
 			// fresh temp dir created for each download to prevent overwriting
-			folder, err := ioutil.TempDir(h.tempPath, filepath.Base(dir))
+			folder, err := os.MkdirTemp(h.tempPath, filepath.Base(dir))
 			if err != nil {
 				h.T.Fatal(err)
 			}
@@ -609,7 +608,7 @@ func (h *Harness) Report() {
 }
 
 func (h *Harness) loadKindConfig(path string) (*kindConfig.Cluster, error) {
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -478,11 +478,11 @@ func (s *Step) String() string {
 }
 
 // LoadYAML loads the resources from a YAML file for a test step:
-// * If the YAML file is called "assert", then it contains objects to
-//   add to the test step's list of assertions.
-// * If the YAML file is called "errors", then it contains objects that,
-//   if seen, mark a test immediately failed.
-// * All other YAML files are considered resources to create.
+//   - If the YAML file is called "assert", then it contains objects to
+//     add to the test step's list of assertions.
+//   - If the YAML file is called "errors", then it contains objects that,
+//     if seen, mark a test immediately failed.
+//   - All other YAML files are considered resources to create.
 func (s *Step) LoadYAML(file string) error {
 	objects, err := testutils.LoadYAMLFromFile(file)
 	if err != nil {

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -170,11 +169,11 @@ func TestRetryWithTimeout(t *testing.T) {
 }
 
 func TestLoadYAML(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "test.yaml")
+	tmpfile, err := os.CreateTemp("", "test.yaml")
 	assert.Nil(t, err)
 	defer tmpfile.Close()
 
-	err = ioutil.WriteFile(tmpfile.Name(), []byte(`
+	err = os.WriteFile(tmpfile.Name(), []byte(`
 apiVersion: v1
 kind: Pod
 metadata:
@@ -246,11 +245,11 @@ spec:
 }
 
 func TestMatchesKind(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "test.yaml")
+	tmpfile, err := os.CreateTemp("", "test.yaml")
 	assert.Nil(t, err)
 	defer tmpfile.Close()
 
-	err = ioutil.WriteFile(tmpfile.Name(), []byte(`
+	err = os.WriteFile(tmpfile.Name(), []byte(`
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
Bump linter to 1.49.0

* resolutions use of deprecated functions
* removal of 3 linters which were abandoned
* gofmt formatting fixed for use of * in godoc

Signed-off-by: Ken Sipe <kensipe@gmail.com>

