### PR TITLE
[WiP] Support template expansion of YAML files

### DIFF
--- a/pkg/file/files.go
+++ b/pkg/file/files.go
@@ -13,11 +13,11 @@ import (
 )
 
 // from a list of paths, returns an array of runtime objects
-func ToObjects(paths []string) ([]client.Object, error) {
+func ToObjects(paths []string, templatingContext testutils.TemplatingContext) ([]client.Object, error) {
 	apply := []client.Object{}
 
 	for _, path := range paths {
-		objs, err := testutils.LoadYAMLFromFile(path)
+		objs, err := testutils.LoadYAMLFromFile(path, templatingContext)
 		if err != nil {
 			return nil, fmt.Errorf("file %q load yaml error: %w", path, err)
 		}

--- a/pkg/file/files_test.go
+++ b/pkg/file/files_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"github.com/kudobuilder/kuttl/pkg/test/utils"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,13 +52,13 @@ func TestFromPath(t *testing.T) {
 
 func TestToRuntimeObjects(t *testing.T) {
 	files := []string{"testdata/path/test1.yaml"}
-	objs, err := ToObjects(files)
+	objs, err := ToObjects(files, utils.TemplatingContext{})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(objs))
 	assert.Equal(t, "Pod", objs[0].GetObjectKind().GroupVersionKind().Kind)
 
 	files = append(files, "testdata/path/test2.yaml")
-	_, err = ToObjects(files)
+	_, err = ToObjects(files, utils.TemplatingContext{})
 	assert.Error(t, err, "file \"testdata/path/test2.yaml\" load yaml error")
 }
 

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -88,7 +88,7 @@ For more detailed documentation, visit: https://kuttl.dev`,
 
 			// Load the configuration YAML into options.
 			if configPath != "" {
-				objects, err := testutils.LoadYAMLFromFile(configPath)
+				objects, err := testutils.LoadYAMLFromFile(configPath, testutils.TemplatingContext{})
 				if err != nil {
 					return err
 				}

--- a/pkg/test/assert.go
+++ b/pkg/test/assert.go
@@ -18,7 +18,7 @@ func Assert(namespace string, timeout int, assertFiles ...string) error {
 	var objects []client.Object
 
 	for _, file := range assertFiles {
-		o, err := ObjectsFromPath(file, "")
+		o, err := ObjectsFromPath(file, "", testutils.GetTemplatingContext(namespace))
 		if err != nil {
 			return err
 		}
@@ -64,7 +64,7 @@ func Errors(namespace string, timeout int, errorFiles ...string) error {
 	var objects []client.Object
 
 	for _, file := range errorFiles {
-		o, err := ObjectsFromPath(file, "")
+		o, err := ObjectsFromPath(file, "", testutils.GetTemplatingContext(namespace))
 		if err != nil {
 			return err
 		}

--- a/pkg/test/case_integration_test.go
+++ b/pkg/test/case_integration_test.go
@@ -100,6 +100,7 @@ func TestMultiClusterCase(t *testing.T) {
 			return testenv.DiscoveryClient, nil
 		},
 	}
+	c.determineNamespace()
 
 	c.Run(t, &report.Testcase{})
 }

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -335,7 +335,7 @@ func TestCheckedTypeAssertions(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			step := Step{}
 			path := fmt.Sprintf("step_integration_test_data/error_detect/00-%s.yaml", test.name)
-			assert.EqualError(t, step.LoadYAML(path),
+			assert.EqualError(t, step.LoadYAML(path, utils.GetTemplatingContext("")),
 				fmt.Sprintf("failed to load %s object from %s: it contains an object of type *unstructured.Unstructured",
 					test.typeName, path))
 		})
@@ -350,7 +350,7 @@ func TestApplyExpansion(t *testing.T) {
 
 	step := Step{Dir: "step_integration_test_data/assert_expand/"}
 	path := "step_integration_test_data/assert_expand/00-step1.yaml"
-	err := step.LoadYAML(path)
+	err := step.LoadYAML(path, utils.GetTemplatingContext(""))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(step.Apply))
 
@@ -362,12 +362,12 @@ func TestOverriddenKubeconfigPathResolution(t *testing.T) {
 		os.Unsetenv("SUBPATH")
 	}()
 	stepRelativePath := &Step{Dir: "step_integration_test_data/kubeconfig_path_resolution/"}
-	err := stepRelativePath.LoadYAML("step_integration_test_data/kubeconfig_path_resolution/00-step1.yaml")
+	err := stepRelativePath.LoadYAML("step_integration_test_data/kubeconfig_path_resolution/00-step1.yaml", utils.GetTemplatingContext(""))
 	assert.NoError(t, err)
 	assert.Equal(t, "step_integration_test_data/kubeconfig_path_resolution/kubeconfig-test.yaml", stepRelativePath.Kubeconfig)
 
 	stepAbsPath := &Step{Dir: "step_integration_test_data/kubeconfig_path_resolution/"}
-	err = stepAbsPath.LoadYAML("step_integration_test_data/kubeconfig_path_resolution/00-step2.yaml")
+	err = stepAbsPath.LoadYAML("step_integration_test_data/kubeconfig_path_resolution/00-step2.yaml", utils.GetTemplatingContext(""))
 	assert.NoError(t, err)
 	assert.Equal(t, "/absolute/kubeconfig-test.yaml", stepAbsPath.Kubeconfig)
 }
@@ -381,9 +381,9 @@ func TestTwoTestStepping(t *testing.T) {
 	}
 
 	// 2 apply files in 1 step
-	err := step.LoadYAML("step_integration_test_data/two_step/00-step1.yaml")
+	err := step.LoadYAML("step_integration_test_data/two_step/00-step1.yaml", utils.GetTemplatingContext(""))
 	assert.NoError(t, err)
-	err = step.LoadYAML("step_integration_test_data/two_step/00-step2.yaml")
+	err = step.LoadYAML("step_integration_test_data/two_step/00-step2.yaml", utils.GetTemplatingContext(""))
 	assert.Error(t, err, "more than 1 TestStep not allowed in step \"twostepping\"")
 
 	// 2 teststeps in 1 file in 1 step
@@ -392,7 +392,7 @@ func TestTwoTestStepping(t *testing.T) {
 		Index: 0,
 		Apply: apply,
 	}
-	err = step.LoadYAML("step_integration_test_data/two_step/01-step1.yaml")
+	err = step.LoadYAML("step_integration_test_data/two_step/01-step1.yaml", utils.GetTemplatingContext(""))
 	assert.Error(t, err, "more than 1 TestStep not allowed in step \"twostepping\"")
 }
 
@@ -452,7 +452,7 @@ func TestAssertCommandsValidCommandRunsOk(t *testing.T) {
 	}
 
 	// Load test that has an echo command, so it should run ok, and don't return any errors
-	err := step.LoadYAML("step_integration_test_data/assert_commands/valid_command/00-assert.yaml")
+	err := step.LoadYAML("step_integration_test_data/assert_commands/valid_command/00-assert.yaml", utils.GetTemplatingContext(""))
 	assert.NoError(t, err)
 
 	errors := step.Run("irrelevant")
@@ -470,7 +470,7 @@ func TestAssertCommandsMultipleCommandRunsOk(t *testing.T) {
 	}
 
 	// Load test that has an echo command, so it should run ok, and don't return any errors
-	err := step.LoadYAML("step_integration_test_data/assert_commands/multiple_commands/00-assert.yaml")
+	err := step.LoadYAML("step_integration_test_data/assert_commands/multiple_commands/00-assert.yaml", utils.GetTemplatingContext(""))
 	assert.NoError(t, err)
 
 	errors := step.Run("irrelevant")
@@ -488,7 +488,7 @@ func TestAssertCommandsMissingCommandFails(t *testing.T) {
 	}
 
 	// Load test that has an command that is not present (thiscommanddoesnotexist), so it should return an error
-	err := step.LoadYAML("step_integration_test_data/assert_commands/command_does_not_exist/00-assert.yaml")
+	err := step.LoadYAML("step_integration_test_data/assert_commands/command_does_not_exist/00-assert.yaml", utils.GetTemplatingContext(""))
 	assert.NoError(t, err)
 
 	errors := step.Run("irrelevant")
@@ -506,7 +506,7 @@ func TestAssertCommandsFailingCommandFails(t *testing.T) {
 	}
 
 	// Load test that has an command that is present but will allways fail (false), so we should get back the error.
-	err := step.LoadYAML("step_integration_test_data/assert_commands/failing_comand/00-assert.yaml")
+	err := step.LoadYAML("step_integration_test_data/assert_commands/failing_comand/00-assert.yaml", utils.GetTemplatingContext(""))
 	assert.NoError(t, err)
 
 	errors := step.Run("irrelevant")
@@ -525,7 +525,7 @@ func TestAssertCommandsShouldTimeout(t *testing.T) {
 
 	// Load test that has an command that sleeps for 5 seconds, while the timeout for the step is 1,
 	// so we should get back the error, and the test should run in less slightly more than 1 seconds.
-	err := step.LoadYAML("step_integration_test_data/assert_commands/timingout_command/00-assert.yaml")
+	err := step.LoadYAML("step_integration_test_data/assert_commands/timingout_command/00-assert.yaml", utils.GetTemplatingContext(""))
 	assert.NoError(t, err)
 
 	start := time.Now()

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -200,7 +200,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	objs, err := LoadYAMLFromFile(tmpfile.Name())
+	objs, err := LoadYAMLFromFile(tmpfile.Name(), TemplatingContext{})
 	assert.Nil(t, err)
 
 	assert.Equal(t, &unstructured.Unstructured{
@@ -269,7 +269,7 @@ metadata:
 		t.Fatal(err)
 	}
 
-	objs, err := LoadYAMLFromFile(tmpfile.Name())
+	objs, err := LoadYAMLFromFile(tmpfile.Name(), TemplatingContext{})
 	assert.Nil(t, err)
 
 	crd := NewResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "", "")


### PR DESCRIPTION
# Why do we need it

I encountered a few cases where I needed `kuttl` to match a field to a value that depends on the execution environment. Examples:
- product version string in a `status` field in order to verify that an upgrade succeeded. The version string is produced based on git commit SHA dynamically by the build tooling.
- cluster-scoped resources whose name includes the name of the test namespace

I ended up creating a `TestAssert` containing a script which:
1. does poor man's template expansion using `envsubst`
2. invokes a (nested) `kuttl assert` on the resulting file
3. deletes the temporary assert file

As you can imagine, the result is not pretty or straightforward to understand at first sight.

Other issues that I found which might (or might not) be helped by this change: https://github.com/kudobuilder/kuttl/issues/70 https://github.com/kudobuilder/kuttl/issues/160 https://github.com/kudobuilder/kuttl/issues/350 https://github.com/kudobuilder/kuttl/issues/288 https://github.com/kudobuilder/kuttl/issues/262 https://github.com/kudobuilder/kuttl/issues/224 https://github.com/kudobuilder/kuttl/issues/222 https://github.com/kudobuilder/kuttl/issues/203

# What this PR does

During a recent team hackathon I took a stab at finding out how difficult it would be to do the template expansion directly within `kuttl`. Turns out it was not too difficult, and the result works. But please keep in mind this is a *hack*, not meant to be merged as is. But might be a useful inspiration on the necessary work.

For backwards compatibility I introduced a notion of `*.gotmpl.yaml` files, and only these are expanded. The dictionary of expansion keys (`TemplatingContext`) also needs some more thought. For now it consists of the namespace and environment.