### PR TITLE
Add support for linux arm64 for krew-index

### DIFF
--- a/hack/generate_krew.sh
+++ b/hack/generate_krew.sh
@@ -67,6 +67,7 @@ spec:
 EOF
 
 generate_platform linux amd64 ./kubectl-kuttl >> kuttl.yaml
+generate_platform linux arm64 ./kubectl-kuttl >> kuttl.yaml
 generate_platform linux 386 ./kubectl-kuttl >> kuttl.yaml
 generate_platform darwin amd64 ./kubectl-kuttl >> kuttl.yaml
 generate_platform darwin arm64 ./kubectl-kuttl >> kuttl.yaml


### PR DESCRIPTION
Signed-off-by: imusmanmalik <usmanmalik@engineer.com>

Builds are present for linux arm64 and installing `kuttl` on linux arm64 fails.

PR at `krew-index` -> https://github.com/kubernetes-sigs/krew-index/pull/2693
