### PR TITLE
Allow user to set reportName

### DIFF
--- a/crds/testsuite-json-schema.yaml
+++ b/crds/testsuite-json-schema.yaml
@@ -105,7 +105,7 @@ properties:
     type: string
   reportName:
     description: The name of report to create. This field is not used unless reportFormat is set.
-    default: "kuttl-test"
+    default: "kuttl-report"
     type: string
   namespace:
     description: |

--- a/crds/testsuite_crd.yaml
+++ b/crds/testsuite_crd.yaml
@@ -121,7 +121,7 @@ spec:
               type: string
             reportName:
               description: The name of report to create. This field is not used unless reportFormat is set.
-              default: "kuttl-test"
+              default: "kuttl-report"
               type: string
             namespace:
               description: |

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -64,7 +64,7 @@ type TestSuite struct {
 	// maps to report.Type, however we don't want generated.deepcopy to have reference to it.
 	ReportFormat string `json:"reportFormat"`
 
-	// ReportName defines the name of report to create.  It defaults to "kuttl-test" and is not used unless ReportFormat is defined.
+	// ReportName defines the name of report to create.  It defaults to "kuttl-report" and is not used unless ReportFormat is defined.
 	ReportName string `json:"reportName"`
 	// Namespace defines the namespace to use for tests
 	// The value "" means to auto-generate tests namespaces, these namespaces will be created and removed for each test

--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -58,6 +58,7 @@ func newTestCmd() *cobra.Command {
 	mockControllerFile := ""
 	timeout := 30
 	reportFormat := ""
+	reportName := "kuttl-report"
 	namespace := ""
 	suppress := []string{}
 
@@ -111,7 +112,6 @@ For more detailed documentation, visit: https://kuttl.dev`,
 			}
 
 			// Override configuration file options with any command line flags if they are set.
-			options.ReportName = "kuttl-test"
 			if isSet(flags, "crd-dir") {
 				options.CRDDir = crdDir
 			}
@@ -169,6 +169,10 @@ For more detailed documentation, visit: https://kuttl.dev`,
 			if isSet(flags, "report") {
 				var ftype = report.Type(strings.ToLower(reportFormat))
 				options.ReportFormat = reportType(ftype)
+			}
+
+			if isSet(flags, "report-name") {
+				options.ReportName = reportName
 			}
 
 			if isSet(flags, "artifacts-dir") {
@@ -250,6 +254,7 @@ For more detailed documentation, visit: https://kuttl.dev`,
 	testCmd.Flags().IntVar(&parallel, "parallel", 8, "The maximum number of tests to run at once.")
 	testCmd.Flags().IntVar(&timeout, "timeout", 30, "The timeout to use as default for TestSuite configuration.")
 	testCmd.Flags().StringVar(&reportFormat, "report", "", "Specify JSON|XML for report.  Report location determined by --artifacts-dir.")
+	testCmd.Flags().StringVar(&reportName, "report-name", "kuttl-report", "Name for the report.  Report location determined by --artifacts-dir and report file type determined by --report.")
 	testCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Namespace to use for tests. Provided namespaces must exist prior to running tests.")
 	testCmd.Flags().StringSliceVar(&suppress, "suppress-log", []string{}, "Suppress logging for these kinds of logs (events).")
 	// This cannot be a global flag because pkg/test/utils.RunTests calls flag.Parse which barfs on unknown top-level flags.

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -602,9 +602,18 @@ func (h *Harness) Report() {
 	if len(h.TestSuite.ReportFormat) == 0 {
 		return
 	}
-	if err := h.report.Report(h.TestSuite.ArtifactsDir, h.TestSuite.ReportName, report.Type(h.TestSuite.ReportFormat)); err != nil {
+	if err := h.report.Report(h.TestSuite.ArtifactsDir, h.GetReportName(), report.Type(h.TestSuite.ReportFormat)); err != nil {
 		h.fatal(fmt.Errorf("fatal error writing report: %v", err))
 	}
+}
+
+// GetReportName returns the configured ReportName.
+func (h *Harness) GetReportName() string {
+	reportName := "kuttl-report"
+	if h.TestSuite.ReportName != "" {
+		reportName = h.TestSuite.ReportName
+	}
+	return reportName
 }
 
 func (h *Harness) loadKindConfig(path string) (*kindConfig.Cluster, error) {

--- a/pkg/test/harness_test.go
+++ b/pkg/test/harness_test.go
@@ -20,6 +20,14 @@ func TestGetTimeout(t *testing.T) {
 	assert.Equal(t, 45, h.GetTimeout())
 }
 
+func TestGetReportName(t *testing.T) {
+	h := Harness{}
+	assert.Equal(t, "kuttl-report", h.GetReportName())
+
+	h.TestSuite.ReportName = "special-kuttl-report"
+	assert.Equal(t, "special-kuttl-report", h.GetReportName())
+}
+
 type dockerMock struct {
 	ImageWriter *io.PipeWriter
 	imageReader *io.PipeReader


### PR DESCRIPTION
**What this PR does / why we need it**:

* change default report name to `kuttl-report` -- I can nix this part if you don't want it, but it seems to me that `kuttl-test.json`/`kuttl-test.xml` is too close to `kuttl-test.yaml`, the default config name, and liable to lead to some confusion.
* override default report name according to config file's `reportName` field
* override default or config file report name according to command line option --report-name

Signed-off-by: Ben Blattberg <ben.blattberg@crunchydata.com>

Fixes #394 
Fixes #284 