### PR TITLE
fix: step cleanup not capturing current step

### DIFF
--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -347,11 +347,11 @@ func (t *Case) Run(test *testing.T, tc *report.Testcase) {
 		tc.Assertions += len(testStep.Errors)
 
 		if !t.SkipDelete {
-			defer func() {
-				if err := testStep.Clean(ns.Name); err != nil {
+			defer func(step *Step) {
+				if err := step.Clean(ns.Name); err != nil {
 					test.Error(err)
 				}
-			}()
+			}(testStep)
 		}
 
 		if errs := testStep.Run(ns.Name); len(errs) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes step cleanup not capturing the current step.

Without that, cleanup is only invoked with the last step pointer (called multiple times, one per step).