### PR TITLE
refactor: use t.Cleanup instead of defer

### DIFF
--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestExpandWithMap(t *testing.T) {
 	os.Setenv("KUTTL_TEST_123", "hello")
-	defer func() {
+	t.Cleanup(func() {
 		os.Unsetenv("KUTTL_TEST_123")
-	}()
+	})
 	assert.Equal(t, "hello $  world", ExpandWithMap("$KUTTL_TEST_123 $$ $DOES_NOT_EXIST_1234 ${EXPAND_ME}", map[string]string{
 		"EXPAND_ME": "world",
 	}))

--- a/pkg/test/case_integration_test.go
+++ b/pkg/test/case_integration_test.go
@@ -21,14 +21,14 @@ func TestMultiClusterCase(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer testenv.Environment.Stop()
+	t.Cleanup(testenv.Environment.Stop)
 
 	testenv2, err := testutils.StartTestEnvironment(testutils.APIServerDefaultArgs, false)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	defer testenv2.Environment.Stop()
+	t.Cleanup(testenv2.Environment.Stop)
 
 	podSpec := map[string]interface{}{
 		"restartPolicy": "Never",
@@ -45,7 +45,9 @@ func TestMultiClusterCase(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	defer os.Remove(tmpfile.Name())
+	t.Cleanup(func() {
+		os.Remove(tmpfile.Name())
+	})
 	if err := testutils.Kubeconfig(testenv2.Config, tmpfile); err != nil {
 		t.Error(err)
 		return

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -351,7 +351,7 @@ func (h *Harness) DockerClient() (testutils.DockerClient, error) {
 // tests at dir.
 func (h *Harness) RunTests() {
 	// cleanup after running tests
-	defer h.Stop()
+	h.T.Cleanup(h.Stop)
 	h.T.Log("running tests")
 
 	testDirs := h.testPreProcessing()

--- a/pkg/test/harness_integration_test.go
+++ b/pkg/test/harness_integration_test.go
@@ -63,7 +63,7 @@ func TestRunBackgroundCommands(t *testing.T) {
 	h.TestSuite.Commands = commands
 
 	h.Setup()
-	defer h.Stop()
+	t.Cleanup(h.Stop)
 
 	// setup creates bg processes
 	assert.Equal(t, 1, len(h.bgProcesses))

--- a/pkg/test/kind_integration_test.go
+++ b/pkg/test/kind_integration_test.go
@@ -36,11 +36,11 @@ func TestAddContainers(t *testing.T) {
 		t.Fatalf("failed to start KIND cluster: %v", err)
 	}
 
-	defer func() {
+	t.Cleanup(func() {
 		if err := kind.Stop(); err != nil {
 			t.Fatalf("failed to stop KIND cluster: %v", err)
 		}
-	}()
+	})
 
 	docker, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv)
 	if err != nil {

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -347,9 +347,9 @@ func TestCheckedTypeAssertions(t *testing.T) {
 
 func TestApplyExpansion(t *testing.T) {
 	os.Setenv("TEST_FOO", "test")
-	defer func() {
+	t.Cleanup(func() {
 		os.Unsetenv("TEST_FOO")
-	}()
+	})
 
 	step := Step{Dir: "step_integration_test_data/assert_expand/"}
 	path := "step_integration_test_data/assert_expand/00-step1.yaml"
@@ -361,9 +361,9 @@ func TestApplyExpansion(t *testing.T) {
 
 func TestOverriddenKubeconfigPathResolution(t *testing.T) {
 	os.Setenv("SUBPATH", "test")
-	defer func() {
+	t.Cleanup(func() {
 		os.Unsetenv("SUBPATH")
-	}()
+	})
 	stepRelativePath := &Step{Dir: "step_integration_test_data/kubeconfig_path_resolution/"}
 	err := stepRelativePath.LoadYAML("step_integration_test_data/kubeconfig_path_resolution/00-step1.yaml")
 	assert.NoError(t, err)


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR makes use `t.Cleanup` instead of `defer`.
