### PR TITLE
Refactor Report Name function

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -602,18 +602,17 @@ func (h *Harness) Report() {
 	if len(h.TestSuite.ReportFormat) == 0 {
 		return
 	}
-	if err := h.report.Report(h.TestSuite.ArtifactsDir, h.GetReportName(), report.Type(h.TestSuite.ReportFormat)); err != nil {
+	if err := h.report.Report(h.TestSuite.ArtifactsDir, h.reportName(), report.Type(h.TestSuite.ReportFormat)); err != nil {
 		h.fatal(fmt.Errorf("fatal error writing report: %v", err))
 	}
 }
 
-// GetReportName returns the configured ReportName.
-func (h *Harness) GetReportName() string {
-	reportName := "kuttl-report"
+// reportName returns the configured ReportName.
+func (h *Harness) reportName() string {
 	if h.TestSuite.ReportName != "" {
-		reportName = h.TestSuite.ReportName
+		return h.TestSuite.ReportName
 	}
-	return reportName
+	return "kuttl-report"
 }
 
 func (h *Harness) loadKindConfig(path string) (*kindConfig.Cluster, error) {

--- a/pkg/test/harness_test.go
+++ b/pkg/test/harness_test.go
@@ -22,10 +22,10 @@ func TestGetTimeout(t *testing.T) {
 
 func TestGetReportName(t *testing.T) {
 	h := Harness{}
-	assert.Equal(t, "kuttl-report", h.GetReportName())
+	assert.Equal(t, "kuttl-report", h.reportName())
 
 	h.TestSuite.ReportName = "special-kuttl-report"
-	assert.Equal(t, "special-kuttl-report", h.GetReportName())
+	assert.Equal(t, "special-kuttl-report", h.reportName())
 }
 
 type dockerMock struct {


### PR DESCRIPTION
refactors to PR https://github.com/kudobuilder/kuttl/pull/395/

* removal of "Get" in GetReportName
* no need to export the function

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #
