### PR TITLE
fix: prefer events v1 over v1beta1

### DIFF
--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -174,10 +174,10 @@ func (t *Case) CollectEvents(namespace string) {
 		return
 	}
 
-	err = t.collectEventsBeta1(cl, namespace)
+	err = t.collectEventsV1(cl, namespace)
 	if err != nil {
-		t.Logger.Log("Trying with events eventsv1 API...")
-		err = t.collectEventsV1(cl, namespace)
+		t.Logger.Log("Trying with events eventsv1beta1 API...")
+		err = t.collectEventsBeta1(cl, namespace)
 		if err != nil {
 			t.Logger.Log("Trying with events corev1 API...")
 			err = t.collectEventsCoreV1(cl, namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR gives preference to events v1 over v1beta1 and falls back to v1beta1 if v1 didn't work.

Fixes #373 
Fixes #414