### PR TITLE
fix: wait namespace is actually deleted (#413)

### DIFF
--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -153,6 +153,15 @@ For more detailed documentation, visit: https://kuttl.dev`,
 				return errors.New("only use --attach-control-plane-output with --start-control-plane")
 			}
 
+			// if we are working with a control plane we can not wait to delete ns (there is no ns controller)
+			// this is added before flags potentially override.  control plane should skip ns and cluster delete but
+			// perhaps there are cases where that is part of the test.  In general, there is no cluster to delete and
+			// there is no namespace controller.
+			if options.StartControlPlane {
+				options.SkipDelete = true
+				options.SkipClusterDelete = true
+			}
+
 			if isSet(flags, "skip-delete") {
 				options.SkipDelete = skipDelete
 			}

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -16,8 +16,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	eventsbeta1 "k8s.io/api/events/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -69,13 +70,26 @@ func (t *Case) DeleteNamespace(cl client.Client, ns *namespace) error {
 		defer cancel()
 	}
 
-	return cl.Delete(ctx, &corev1.Namespace{
+	nsObj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ns.Name,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Namespace",
 		},
+	}
+
+	if err := cl.Delete(ctx, nsObj); err != nil {
+		return err
+	}
+
+	return wait.PollImmediateUntilWithContext(ctx, 100*time.Millisecond, func(ctx context.Context) (done bool, err error) {
+		actual := &corev1.Namespace{}
+		err = cl.Get(ctx, client.ObjectKey{Name: ns.Name}, actual)
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
 	})
 }
 
@@ -120,7 +134,7 @@ func (t *Case) NamespaceExists(namespace string) (bool, error) {
 	}
 	ns := &corev1.Namespace{}
 	err = cl.Get(context.TODO(), client.ObjectKey{Name: namespace}, ns)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return false, err
 	}
 	return ns.Name == namespace, nil

--- a/pkg/test/case_integration_test.go
+++ b/pkg/test/case_integration_test.go
@@ -62,7 +62,8 @@ func TestMultiClusterCase(t *testing.T) {
 	}
 
 	c := Case{
-		Logger: testutils.NewTestLogger(t, ""),
+		Logger:     testutils.NewTestLogger(t, ""),
+		SkipDelete: true,
 		Steps: []*Step{
 			{
 				Name:  "initialize-testenv",

--- a/pkg/test/harness_integration_test.go
+++ b/pkg/test/harness_integration_test.go
@@ -19,6 +19,7 @@ func TestHarnessRunIntegration(t *testing.T) {
 				"./test_data/",
 			},
 			StartControlPlane: true,
+			SkipDelete:        true,
 			CRDDir:            "./test_crds/",
 		},
 		T: t,
@@ -39,6 +40,7 @@ func TestHarnessRunIntegrationWithConfig(t *testing.T) {
 			},
 			// set as true to skip service account check
 			StartControlPlane: true,
+			SkipDelete:        true,
 			Config:            config,
 			CRDDir:            "./test_crds/",
 		},


### PR DESCRIPTION
Originally on https://github.com/kudobuilder/kuttl/pull/413 was merged and caused failures.   We have issues with contributor PR being tested on circle ci.  This is the same PR.   The squashed commit was reverted and this PR is a cherry-pick of that commit

Co-authored-by: Erik Godding Boye <egboye@gmail.com>
Signed-off-by: Charles-Edouard Brétéché <charles.edouard@nirmata.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
