### PR TITLE
Switch Test CRDs from v1beta1 to v1

### DIFF
--- a/pkg/test/test_crds/ourcrds.yaml
+++ b/pkg/test/test_crds/ourcrds.yaml
@@ -1,11 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-  creationTimestamp: null
   name: ourcrds.kuttl.dev
 spec:
   group: kuttl.dev
@@ -15,28 +14,28 @@ spec:
     plural: ourcrds
     singular: ourcrds
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Ourcrd is the Schema for the ourcrds API.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: OurcrdSpec defines the desired state of Ourcrd.
-      type: object
-  version: v1beta1
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Ourcrd is the Schema for the ourcrds API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OurcrdSpec defines the desired state of Ourcrd.
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/test/test_data/crd-in-step/00-assert.yaml
+++ b/pkg/test/test_data/crd-in-step/00-assert.yaml
@@ -1,5 +1,5 @@
 # Expect the CRD to exist
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mycrds.mycrd.example.com

--- a/pkg/test/test_data/crd-in-step/00-crd.yaml
+++ b/pkg/test/test_data/crd-in-step/00-crd.yaml
@@ -1,14 +1,36 @@
 # Create a CRD
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mycrds.mycrd.example.com
 spec:
-  group: mycrd.example.com
-  version: v1beta1
+  group: mycrd.example.com  
   names:
     kind: MyCRD
     listKind: MyCRDList
     plural: mycrds
     singular: mycrd
   scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Test MyCRD CRD
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/test/test_data/create-or-update/00-assert.yaml
+++ b/pkg/test/test_data/create-or-update/00-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: prowjobs.prow.example.com

--- a/pkg/test/test_data/create-or-update/00-crd.yaml
+++ b/pkg/test/test_data/create-or-update/00-crd.yaml
@@ -1,49 +1,75 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: prowjobs.prow.example.com
 spec:
   group: prow.example.com
-  version: v1
   names:
     kind: ProwJob
     singular: prowjob
     plural: prowjobs
   scope: Namespaced
-  additionalPrinterColumns:
-  - name: Job
-    type: string
-    description: The name of the job being run.
-    JSONPath: .spec.job
-  - name: BuildId
-    type: string
-    description: The ID of the job being run.
-    JSONPath: .status.build_id
-  - name: Type
-    type: string
-    description: The type of job being run.
-    JSONPath: .spec.type
-  - name: Org
-    type: string
-    description: The org for which the job is running.
-    JSONPath: .spec.refs.org
-  - name: Repo
-    type: string
-    description: The repo for which the job is running.
-    JSONPath: .spec.refs.repo
-  - name: Pulls
-    type: string
-    description: The pulls for which the job is running.
-    JSONPath: ".spec.refs.pulls[*].number"
-  - name: StartTime
-    type: date
-    description: When the job started running.
-    JSONPath: .status.startTime
-  - name: CompletionTime
-    type: date
-    description: When the job finished running.
-    JSONPath: .status.completionTime
-  - name: State
-    description: The state of the job.
-    type: string
-    JSONPath: .status.state
+  versions:
+  - additionalPrinterColumns:
+    - name: Job
+      type: string
+      description: The name of the job being run.
+      jsonPath: .spec.job
+    - name: BuildId
+      type: string
+      description: The ID of the job being run.
+      jsonPath: .status.build_id
+    - name: Type
+      type: string
+      description: The type of job being run.
+      jsonPath: .spec.type
+    - name: Org
+      type: string
+      description: The org for which the job is running.
+      jsonPath: .spec.refs.org
+    - name: Repo
+      type: string
+      description: The repo for which the job is running.
+      jsonPath: .spec.refs.repo
+    - name: Pulls
+      type: string
+      description: The pulls for which the job is running.
+      jsonPath: ".spec.refs.pulls[*].number"
+    - name: StartTime
+      type: date
+      description: When the job started running.
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      description: When the job finished running.
+      jsonPath: .status.completionTime
+    - name: State
+      description: The state of the job.
+      type: string
+      jsonPath: .status.state
+    name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: ProwJob contains the spec as well as runtime metadata.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object


### PR DESCRIPTION
Way over due!  Switching CRDs to v1 as we move testing infrastructure to versions that do not support crd v1beta1

**What this PR does / why we need it**:
After this merges, we will switch to a later version of the testenv 

Fixes #
