### PR TITLE
Do not skip cluster delete on testenv

### DIFF
--- a/pkg/kuttlctl/cmd/test.go
+++ b/pkg/kuttlctl/cmd/test.go
@@ -159,7 +159,6 @@ For more detailed documentation, visit: https://kuttl.dev`,
 			// there is no namespace controller.
 			if options.StartControlPlane {
 				options.SkipDelete = true
-				options.SkipClusterDelete = true
 			}
 
 			if isSet(flags, "skip-delete") {


### PR DESCRIPTION
Previous PR #422 skipped cluster delete as part of fix, however we need that.  the change leaked etcd / api-server.  If someone wants to leave it up, they can use the flag or config.  however we need to skip ns delete by default, which can also be overridden if desired.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #
