### PR TITLE
Bump kubectl to 1.26 in kuttl docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN microdnf install vim tar gzip
 RUN echo 'alias vi=vim' >> ~/.bashrc
 
-#  kube 1.18
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+#  kube 1.26
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.26.0/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

Bump kubectl to 1.26 in kuttl docker image
1.18 was released on 16 juin 2021 and is now EOLed, see https://kubernetes.io/releases/

https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

