### PR TITLE
fix(crd): kindConfig type

### DIFF
--- a/crds/testsuite-json-schema.yaml
+++ b/crds/testsuite-json-schema.yaml
@@ -30,7 +30,7 @@ properties:
     default: false
   kindConfig:
     description: Path to the KIND configuration file to use.
-    type: boolean
+    type: string
   kindContext:
     description: KIND context to use.
     type: string

--- a/crds/testsuite_crd.yaml
+++ b/crds/testsuite_crd.yaml
@@ -46,7 +46,7 @@ spec:
               default: false
             kindConfig:
               description: Path to the KIND configuration file to use.
-              type: boolean
+              type: string
             kindContext:
               description: KIND context to use.
               type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the type for `kindConfig`.

Fixes #476 
