### PR TITLE
Support for excluding subset of tests 

### DIFF
--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -77,6 +77,10 @@ type TestSuite struct {
 	Suppress []string `json:"suppress"`
 
 	Config *RestConfig `json:"config,omitempty"`
+
+	// Test sub directories that needs to be excluded from the test run that may otherwise be included with `TestDirs`.
+	// Include all directories specified in `TestDirs`` and exclude those specified in `TestExcludeDirs`.
+	TestExcludeDirs []string `json:"testExcludeDirs,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -79,7 +79,7 @@ type TestSuite struct {
 	Config *RestConfig `json:"config,omitempty"`
 
 	// Test sub directories that needs to be excluded from the test run that may otherwise be included with `TestDirs`.
-	// Include all directories specified in `TestDirs`` and exclude those specified in `TestExcludeDirs`.
+	// Include all directories specified in `TestDirs` and exclude those specified in `TestExcludeDirs`.
 	TestExcludeDirs []string `json:"testExcludeDirs,omitempty"`
 }
 

--- a/pkg/apis/testharness/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/testharness/v1beta1/zz_generated.deepcopy.go
@@ -239,6 +239,11 @@ func (in *TestSuite) DeepCopyInto(out *TestSuite) {
 		in, out := &in.Config, &out.Config
 		*out = (*in).DeepCopy()
 	}
+	if in.TestExcludeDirs != nil {
+		in, out := &in.TestExcludeDirs, &out.TestExcludeDirs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This PR is a proposal/suggestion for allowing users to provide Test excludes as part of the `TestSuite`. Its still work in progress PR and would like to understand if the community finds this useful.

In one of our project where we use `kuttl` test framework for our e2e tests. We have a scenario where we have to skip some subset of tests based on some predefined conditions. 

Example scenario: 
We have to run all tests under `tests/e2e` directory except for the below tests
```
1-031_validate_toolchain 
1-085_validate_dynamic_plugin_installation 
1-036_validate_keycloak_resource_reqs 
1-038_validate_productized_images 
1-051-validate_csv_permissions 
1-073_validate_rhsso 
1-077_validate_disable_dex_removed 
1-090_validate_permissions
```
We couldn't find an easy way of doing that. We had to copy all the tests to a temporary location and had to remove the test sub directories (`rm -rf <test_sub_dir>`) that needs to be skipped and run the tests from that temporary directory. This is not the ideal way of excluding tests. So I propose to add a new attribute in `TestSuite` CR called `testExcludeDirs` where user can specify the test sub directories they would like to exclude and run the remaining tests that are present in the `testDirs`.

This feature could also provide an easy way to exclude tests that are broken and needs to be fixed.

Note: If there are better ways of handling test excludes, without requiring this change, please let me know and I am open to use that approach.

