### PR TITLE
Use .Script to describe command if .Command is empty.

### DIFF
--- a/pkg/apis/testharness/v1beta1/command.go
+++ b/pkg/apis/testharness/v1beta1/command.go
@@ -1,0 +1,51 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import "strings"
+
+func (c *Command) String() string {
+	if c.Command == "" && c.Script == "" {
+		return "(invalid command with neither Command nor Script set)"
+	}
+	if c.Command != "" && c.Script != "" {
+		return "(invalid command with both Command and Script set)"
+	}
+	if c.Command != "" {
+		return c.Command
+	}
+	return summarize(c.Script)
+}
+
+// summarize returns a short representation of a multi-line command.
+func summarize(script string) string {
+	var lines []string
+	for i, line := range strings.Split(script, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if i == 0 && strings.HasPrefix(line, "set -") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	joined := strings.Join(lines, "\\n ")
+	if len(joined) > 70 {
+		return joined[:67] + "..."
+	}
+	return joined
+}

--- a/pkg/apis/testharness/v1beta1/command.go
+++ b/pkg/apis/testharness/v1beta1/command.go
@@ -17,6 +17,9 @@ package v1beta1
 
 import "strings"
 
+// String returns a human-readable representation of a Command.
+// In particular, when the .Script field is set, we try to omit comments
+// as well as `set -...` commands, and elide long content.
 func (c *Command) String() string {
 	if c.Command == "" && c.Script == "" {
 		return "(invalid command with neither Command nor Script set)"
@@ -30,7 +33,8 @@ func (c *Command) String() string {
 	return summarize(c.Script)
 }
 
-// summarize returns a short representation of a multi-line command.
+// summarize returns a short representation of a multi-line shell script.
+// It tries to remove comments and `set -...` commands.
 func summarize(script string) string {
 	var lines []string
 	for i, line := range strings.Split(script, "\n") {
@@ -43,9 +47,11 @@ func summarize(script string) string {
 		}
 		lines = append(lines, line)
 	}
-	joined := strings.Join(lines, "\\n ")
-	if len(joined) > 70 {
-		return joined[:67] + "..."
+	joined := strings.Join(lines, `\n `)
+	const maxLen = 70
+	if len(joined) > maxLen {
+		const ellipsis = "..."
+		return joined[:(maxLen-len(ellipsis))] + ellipsis
 	}
 	return joined
 }

--- a/pkg/apis/testharness/v1beta1/command_test.go
+++ b/pkg/apis/testharness/v1beta1/command_test.go
@@ -1,0 +1,67 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommand_String(t *testing.T) {
+	tests := map[string]struct {
+		command string
+		script  string
+		want    string
+	}{
+		"empty": {
+			want: "(invalid command with neither Command nor Script set)",
+		},
+		"both": {
+			command: "foo",
+			script:  "bar",
+			want:    "(invalid command with both Command and Script set)",
+		},
+		"command": {
+			command: "foo \\ \"; bar",
+			want:    "foo \\ \"; bar",
+		},
+		"short script": {
+			script: "make \\ \"; all",
+			want:   "make \\ \"; all",
+		},
+		"long script": {
+			script: `set -eou pipefail
+first line
+# comment which should be ignored, as should the above set and the following empty line
+
+second line
+AAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAA
+`,
+			want: "first line\\n second line\\n AAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAA AAAA...",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &Command{
+				Command: tt.command,
+				Script:  tt.script,
+			}
+			assert.Equalf(t, tt.want, c.String(), "String()")
+		})
+	}
+}

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1050,7 +1050,7 @@ func GetArgs(ctx context.Context, cmd harness.Command, namespace string, envMap 
 func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd string, stdout io.Writer, stderr io.Writer, logger Logger, timeout int, kubeconfigOverride string) (*exec.Cmd, error) {
 	actualDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("command %q with %w", cmd.Command, err)
+		return nil, fmt.Errorf("command %q with %w", cmd.String(), err)
 	}
 
 	kuttlENV := make(map[string]string)
@@ -1082,7 +1082,7 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 
 	builtCmd, err := GetArgs(cmdCtx, cmd, namespace, kuttlENV)
 	if err != nil {
-		return nil, fmt.Errorf("processing command %q with %w", cmd.Command, err)
+		return nil, fmt.Errorf("processing command %q with %w", cmd.String(), err)
 	}
 
 	logger.Logf("running command: %v", builtCmd.Args)
@@ -1116,7 +1116,7 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 		return nil, nil
 	}
 	if errors.Is(cmdCtx.Err(), context.DeadlineExceeded) {
-		return nil, fmt.Errorf("command %q exceeded %v sec timeout, %w", cmd.Command, timeout, cmdCtx.Err())
+		return nil, fmt.Errorf("command %q exceeded %v sec timeout, %w", cmd.String(), timeout, cmdCtx.Err())
 	}
 	return nil, err
 }

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1118,7 +1118,10 @@ func RunCommand(ctx context.Context, namespace string, cmd harness.Command, cwd 
 	if errors.Is(cmdCtx.Err(), context.DeadlineExceeded) {
 		return nil, fmt.Errorf("command %q exceeded %v sec timeout, %w", cmd.String(), timeout, cmdCtx.Err())
 	}
-	return nil, err
+	if err != nil {
+		return nil, fmt.Errorf("command %q failed, %w", cmd.String(), err)
+	}
+	return nil, nil
 }
 
 func kubeconfigPath(actualDir, override string) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

Introduce a `String()` method that summarizes a command paying attention to `.Script` too, and use it in appropriate places.

While at it, also provide a command summary when it exits non-zero. Before this change, the error was:
```
    logger.go:42: 12:47:52 | basic-central/62-unset-expose-monitoring | running command: [some command and args]
    logger.go:42: 12:47:52 | basic-central/62-unset-expose-monitoring | <command output, if any>
    logger.go:42: 12:47:53 | basic-central/62-unset-expose-monitoring | test step failed 62-unset-expose-monitoring
    logger.go:42: 12:47:53 | basic-central/62-unset-expose-monitoring | collecting log output for [type==pod,label: app=central]
    logger.go:42: 12:47:53 | basic-central/62-unset-expose-monitoring | < potentially pages and pages of collector output >
    [...]
    logger.go:42: 12:47:53 | basic-central/62-unset-expose-monitoring | < potentially pages and pages of collector output >
    case.go:366: failed in step 62-unset-expose-monitoring
    case.go:368: exit status 1
```

After this change, the last line will be a more helpful:
```
    case.go:368: command "some command and args" failed, exit status 1
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #493 
