### PR TITLE
Make $PWD between TestStep and TestAssert commands consistent

### DIFF
--- a/docs/testing/reference.md
+++ b/docs/testing/reference.md
@@ -163,3 +163,5 @@ ignoreFailure | bool   | If set, failures will be ignored.
 background    | bool   | If this command is to be started in the background. These are only support in TestSuites.
 skipLogOutput | bool   | If set, the output from the command is *not* logged. Useful for sensitive logs or to reduce noise.
 timeout       | int    | Override the TestSuite timeout for this command (in seconds).
+
+*Note*: The current working directory (CWD) for `commend`/`script` is the test directory.

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -403,7 +403,7 @@ func (s *Step) CheckResourceAbsent(expected runtime.Object, namespace string) er
 // the errors returned can be a a failure of executing the command or the failure of the command executed.
 func (s *Step) CheckAssertCommands(ctx context.Context, namespace string, commands []harness.TestAssertCommand, timeout int) []error {
 	testErrors := []error{}
-	if _, err := testutils.RunAssertCommands(ctx, s.Logger, namespace, commands, "", timeout, s.Kubeconfig); err != nil {
+	if _, err := testutils.RunAssertCommands(ctx, s.Logger, namespace, commands, s.Dir, timeout, s.Kubeconfig); err != nil {
 		testErrors = append(testErrors, err)
 	}
 	return testErrors

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -533,3 +533,28 @@ func TestAssertCommandsShouldTimeout(t *testing.T) {
 	assert.Less(t, duration, float64(5))
 	assert.Equal(t, len(errors), 1)
 }
+
+func TestAssertCommandsScriptPath(t *testing.T) {
+	step := &Step{
+		Name:            t.Name(),
+		Index:           0,
+		Logger:          testutils.NewTestLogger(t, ""),
+		Client:          func(bool) (client.Client, error) { return testenv.Client, nil },
+		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testenv.DiscoveryClient, nil },
+		Dir:             "step_integration_test_data/assert_commands/path_script/",
+	}
+
+	// TestAssert runs a script via absolute and relative path to the test, so it should run ok, and not return any errors.
+	err := step.LoadYAML("step_integration_test_data/assert_commands/path_script/00-assert.yaml")
+	assert.NoError(t, err)
+
+	errors := step.Run(t, "irrelevant")
+	assert.Equal(t, len(errors), 0)
+
+	// Load the same in a TestStep should behave the same, so it should run ok, and not return any errors.
+	err = step.LoadYAML("step_integration_test_data/assert_commands/path_script/00-step.yaml")
+	assert.NoError(t, err)
+
+	errors = step.Run(t, "irrelevant")
+	assert.Equal(t, len(errors), 0)
+}

--- a/pkg/test/step_integration_test_data/assert_commands/path_script/00-assert.yaml
+++ b/pkg/test/step_integration_test_data/assert_commands/path_script/00-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+commands:
+- script: |
+    echo step call script using relative path
+    ./test/script.sh
+- script: |
+    echo step call script using absolute path
+    $(pwd)/test/script.sh

--- a/pkg/test/step_integration_test_data/assert_commands/path_script/00-step.yaml
+++ b/pkg/test/step_integration_test_data/assert_commands/path_script/00-step.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+- script: |
+    echo step call script using relative path
+    ./test/script.sh
+- script: |
+    echo step call script using absolute path
+    $(pwd)/test/script.sh

--- a/pkg/test/step_integration_test_data/assert_commands/path_script/test/script.sh
+++ b/pkg/test/step_integration_test_data/assert_commands/path_script/test/script.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo -n "$0 $@"
+if [[ $0 == ./* ]]; then
+    echo "relative"
+    exit 0
+elif [[ $0 == /* ]]; then
+    echo "absolute"
+    exit 0
+fi
+exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

The $PWD is different when running commands in TestStep and TestAssert which makes it required e.g. to use abs path to reference a script. This change aligns the path passed into testutils.RunAssertCommands() to be the same as to testutils.RunCommands().

Fixes #322
