### PR TITLE
fix typo in docs/testing/reference.md

### DIFF
--- a/docs/testing/reference.md
+++ b/docs/testing/reference.md
@@ -164,4 +164,4 @@ background    | bool   | If this command is to be started in the background. The
 skipLogOutput | bool   | If set, the output from the command is *not* logged. Useful for sensitive logs or to reduce noise.
 timeout       | int    | Override the TestSuite timeout for this command (in seconds).
 
-*Note*: The current working directory (CWD) for `commend`/`script` is the test directory.
+*Note*: The current working directory (CWD) for `command`/`script` is the test directory.


### PR DESCRIPTION
**What this PR does / why we need it**:

just a typo fix from https://github.com/kudobuilder/kuttl/pull/519
