### PR TITLE
feat: add lazy loading kubeconfigs for Test Steps

### DIFF
--- a/docs/testing/reference.md
+++ b/docs/testing/reference.md
@@ -73,7 +73,7 @@ delete   | list of object references | A list of objects to delete, if they do n
 index    | int                       | Override the test step's index.
 commands | list of [Commands](#commands) | Commands to run prior at the beginning of the test step.
 kubeconfig    | string                       | The Kubeconfig file to use to run the included steps(s).
-kubeconfigLoading    | string                       | Specifies the mode for loading Kubeconfig: Eager/Lazy. Defaults to Eager.
+kubeconfigLoading    | string                | Specifies the mode for loading Kubeconfig and making a cluster connection: `Eager` (when loading the test definition) or `Lazy` (right before executing the step, makes it possible to generate the Kubeconfig in a preceding step). Defaults to `Eager`.
 unitTest    | bool                       | Indicates if the step is a unit test, safe to run without a real Kubernetes cluster.
 
 

--- a/docs/testing/reference.md
+++ b/docs/testing/reference.md
@@ -73,6 +73,7 @@ delete   | list of object references | A list of objects to delete, if they do n
 index    | int                       | Override the test step's index.
 commands | list of [Commands](#commands) | Commands to run prior at the beginning of the test step.
 kubeconfig    | string                       | The Kubeconfig file to use to run the included steps(s).
+kubeconfigLoading    | string                       | Specifies the mode for loading Kubeconfig: Eager/Lazy. Defaults to Eager.
 unitTest    | bool                       | Indicates if the step is a unit test, safe to run without a real Kubernetes cluster.
 
 

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const KubeconfigLoadingEager = "Eager"
 const KubeconfigLoadingLazy = "Lazy"
 
 // Create embedded struct to implement custom DeepCopyInto method

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -6,6 +6,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const KubeconfigLoadingLazy = "Lazy"
+
 // Create embedded struct to implement custom DeepCopyInto method
 type RestConfig struct {
 	RC *rest.Config
@@ -126,8 +128,10 @@ type TestStep struct {
 	// Kubeconfig to use when applying and asserting for this step.
 	Kubeconfig string `json:"kubeconfig,omitempty"`
 
-	// Loads kubeconfig only when the previous steps have finished.
-	LazyLoadKubeconfig bool `json:"lazyLoadKubeconfig,omitempty"`
+	// Specifies the mode for loading Kubeconfig: Eager/Lazy. Defaults to Eager.
+	// +kubebuilder:default=Eager
+	// +kubebuilder:validation:Enum=Eager;Lazy
+	KubeconfigLoading string `json:"kubeconfigLoading,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/testharness/v1beta1/test_types.go
+++ b/pkg/apis/testharness/v1beta1/test_types.go
@@ -125,6 +125,9 @@ type TestStep struct {
 
 	// Kubeconfig to use when applying and asserting for this step.
 	Kubeconfig string `json:"kubeconfig,omitempty"`
+
+	// Loads kubeconfig only when the previous steps have finished.
+	LazyLoadKubeconfig bool `json:"lazyLoadKubeconfig,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -376,7 +376,7 @@ func (t *Case) Run(test *testing.T, ts *report.Testsuite) {
 		if testStep.KubeconfigLoading == v1beta1.KubeconfigLoadingLazy {
 			cl, err = newClient(testStep.Kubeconfig)(false)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("failed to lazy-load kubeconfig '%v': %w", testStep.Kubeconfig, err))
+				errs = append(errs, fmt.Errorf("failed to lazy-load kubeconfig %q: %w", testStep.Kubeconfig, err))
 			} else {
 				clients[testStep.Kubeconfig] = cl
 			}

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -373,6 +373,7 @@ func (t *Case) Run(test *testing.T, ts *report.Testsuite) {
 
 		errs := []error{}
 
+		// Set-up client for lazy-loaded Kubeconfigs
 		if testStep.KubeconfigLoading == v1beta1.KubeconfigLoadingLazy {
 			cl, err = newClient(testStep.Kubeconfig)(false)
 			if err != nil {
@@ -382,7 +383,11 @@ func (t *Case) Run(test *testing.T, ts *report.Testsuite) {
 			}
 		}
 
-		errs = append(errs, testStep.Run(test, ns.Name)...)
+		// Run test case only if no setup errors are encountered
+		if len(errs) == 0 {
+			errs = append(errs, testStep.Run(test, ns.Name)...)
+		}
+
 		if len(errs) > 0 {
 			caseErr := fmt.Errorf("failed in step %s", testStep.String())
 			tc.Failure = report.NewFailure(caseErr.Error(), errs)

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -16,7 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	eventsbeta1 "k8s.io/api/events/v1beta1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -350,7 +349,7 @@ func (t *Case) Run(test *testing.T, ts *report.Testsuite) {
 	}
 
 	for kc, c := range clients {
-		if err = t.CreateNamespace(test, c, ns); apierrors.IsAlreadyExists(err) {
+		if err = t.CreateNamespace(test, c, ns); k8serrors.IsAlreadyExists(err) {
 			t.Logger.Logf("namespace %q already exists, using kubeconfig %q", ns.Name, kc)
 		} else if err != nil {
 			setupReport.Failure = report.NewFailure("failed to create test namespace", []error{err})
@@ -381,7 +380,7 @@ func (t *Case) Run(test *testing.T, ts *report.Testsuite) {
 			cl, err = testStep.Client(false)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to lazy-load kubeconfig: %w", err))
-			} else if err = t.CreateNamespace(test, cl, ns); apierrors.IsAlreadyExists(err) {
+			} else if err = t.CreateNamespace(test, cl, ns); k8serrors.IsAlreadyExists(err) {
 				t.Logger.Logf("namespace %q already exists", ns.Name)
 			} else if err != nil {
 				errs = append(errs, fmt.Errorf("failed to create test namespace: %w", err))

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -334,7 +334,7 @@ func (t *Case) Run(test *testing.T, ts *report.Testsuite) {
 	clients := map[string]client.Client{"": cl}
 
 	for _, testStep := range t.Steps {
-		if clients[testStep.Kubeconfig] != nil || testStep.KubeconfigLoading != v1beta1.KubeconfigLoadingLazy {
+		if clients[testStep.Kubeconfig] != nil || testStep.KubeconfigLoading == v1beta1.KubeconfigLoadingLazy {
 			continue
 		}
 

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -51,10 +51,10 @@ type Step struct {
 
 	Timeout int
 
-	Kubeconfig         string
-	LazyLoadKubeConfig bool
-	Client             func(forceNew bool) (client.Client, error)
-	DiscoveryClient    func() (discovery.DiscoveryInterface, error)
+	Kubeconfig        string
+	KubeconfigLoading string
+	Client            func(forceNew bool) (client.Client, error)
+	DiscoveryClient   func() (discovery.DiscoveryInterface, error)
 
 	Logger testutils.Logger
 }
@@ -556,7 +556,7 @@ func (s *Step) LoadYAML(file string) error {
 				exKubeconfig := env.Expand(s.Step.Kubeconfig)
 				s.Kubeconfig = cleanPath(exKubeconfig, s.Dir)
 			}
-			s.LazyLoadKubeConfig = s.Step.LazyLoadKubeconfig
+			s.KubeconfigLoading = s.Step.KubeconfigLoading
 		} else {
 			applies = append(applies, obj)
 		}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -556,7 +556,15 @@ func (s *Step) LoadYAML(file string) error {
 				exKubeconfig := env.Expand(s.Step.Kubeconfig)
 				s.Kubeconfig = cleanPath(exKubeconfig, s.Dir)
 			}
-			s.KubeconfigLoading = s.Step.KubeconfigLoading
+
+			switch s.Step.KubeconfigLoading {
+			case "":
+				s.KubeconfigLoading = harness.KubeconfigLoadingEager
+			case harness.KubeconfigLoadingEager, harness.KubeconfigLoadingLazy:
+				s.KubeconfigLoading = s.Step.KubeconfigLoading
+			default:
+				return fmt.Errorf("attribute 'kubeconfigLoading' has invalid value %q", s.Step.KubeconfigLoading)
+			}
 		} else {
 			applies = append(applies, obj)
 		}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -51,9 +51,10 @@ type Step struct {
 
 	Timeout int
 
-	Kubeconfig      string
-	Client          func(forceNew bool) (client.Client, error)
-	DiscoveryClient func() (discovery.DiscoveryInterface, error)
+	Kubeconfig         string
+	LazyLoadKubeConfig bool
+	Client             func(forceNew bool) (client.Client, error)
+	DiscoveryClient    func() (discovery.DiscoveryInterface, error)
 
 	Logger testutils.Logger
 }
@@ -555,6 +556,7 @@ func (s *Step) LoadYAML(file string) error {
 				exKubeconfig := env.Expand(s.Step.Kubeconfig)
 				s.Kubeconfig = cleanPath(exKubeconfig, s.Dir)
 			}
+			s.LazyLoadKubeConfig = s.Step.LazyLoadKubeconfig
 		} else {
 			applies = append(applies, obj)
 		}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -558,9 +558,7 @@ func (s *Step) LoadYAML(file string) error {
 			}
 
 			switch s.Step.KubeconfigLoading {
-			case "":
-				s.KubeconfigLoading = harness.KubeconfigLoadingEager
-			case harness.KubeconfigLoadingEager, harness.KubeconfigLoadingLazy:
+			case "", harness.KubeconfigLoadingEager, harness.KubeconfigLoadingLazy:
 				s.KubeconfigLoading = s.Step.KubeconfigLoading
 			default:
 				return fmt.Errorf("attribute 'kubeconfigLoading' has invalid value %q", s.Step.KubeconfigLoading)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This PR adds an attribute `LazyLoadKubeconfig` to the `TestStep` type which can be used to configure whether the `Kubeconfig` specified in the `TestStep` needs to be lazy-loaded, i.e., if the `Kubeconfig` doesn't need to be loaded at the start of the `TestCase` eval.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #539

**Tests**
```
.
├── eager
│   └── loading
│       └── 00-teststep.yaml
├── kubeconfig
├── kuttl-test.yaml
└── lazy
    └── loading
        └── 00-teststep.yaml
```

`eager/loading/00-teststep.yaml`:
```yaml
apiVersion: kuttl.dev/v1beta1
kind: TestStep
commands:
- script: echo hi
kubeconfig: test.kubeconfig
kubeconfigLoading: Eager
```

`lazy/loading/00-teststep.yaml`:
```yaml
apiVersion: kuttl.dev/v1beta1
kind: TestStep
commands:
- script: echo hi
kubeconfig: test.kubeconfig
kubeconfigLoading: Lazy
```


Output on `main`:
```shell
➜  lazy_test git:(main) ✗ go run ../cmd/kubectl-kuttl/main.go test eager
2024/07/04 11:43:22 kutt-test config testdirs is overridden with args: [ eager ]
=== RUN   kuttl
    harness.go:464: starting setup
    harness.go:255: running tests using configured kubeconfig.
    harness.go:278: Successful connection to cluster at: https://127.0.0.1:49639
    harness.go:363: running tests
    harness.go:75: going to run test suite with timeout of 2400 seconds for each step
    harness.go:375: testsuite: eager has 1 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/loading
=== PAUSE kuttl/harness/loading
=== CONT  kuttl/harness/loading
    case.go:344: stat /Users/kumarmallikarjuna/Workspace/oss/kuttl/lazy_test/eager/loading/test.kubeconfig: no such file or directory
=== NAME  kuttl
    harness.go:407: run tests finished
    harness.go:515: cleaning up
    harness.go:572: removing temp folder: ""
--- FAIL: kuttl (0.01s)
    --- FAIL: kuttl/harness (0.00s)
        --- FAIL: kuttl/harness/loading (0.00s)
FAIL
exit status 1
➜  lazy_test git:(main) ✗ go run ../cmd/kubectl-kuttl/main.go test lazy
2024/07/04 11:43:27 kutt-test config testdirs is overridden with args: [ lazy ]
=== RUN   kuttl
    harness.go:464: starting setup
    harness.go:255: running tests using configured kubeconfig.
    harness.go:278: Successful connection to cluster at: https://127.0.0.1:49639
    harness.go:363: running tests
    harness.go:75: going to run test suite with timeout of 2400 seconds for each step
    harness.go:375: testsuite: lazy has 1 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/loading
=== PAUSE kuttl/harness/loading
=== CONT  kuttl/harness/loading
    case.go:344: stat /Users/kumarmallikarjuna/Workspace/oss/kuttl/lazy_test/lazy/loading/test.kubeconfig: no such file or directory
=== NAME  kuttl
    harness.go:407: run tests finished
    harness.go:515: cleaning up
    harness.go:572: removing temp folder: ""
--- FAIL: kuttl (0.02s)
    --- FAIL: kuttl/harness (0.00s)
        --- FAIL: kuttl/harness/loading (0.00s)
FAIL
exit status 1
```

Output after these changes:
```shell
➜  lazy_test git:(tmp-kubeconfig-lazy-loading) ✗ go run ../cmd/kubectl-kuttl/main.go test eager
2024/07/04 11:41:15 kutt-test config testdirs is overridden with args: [ eager ]
=== RUN   kuttl
    harness.go:464: starting setup
    harness.go:255: running tests using configured kubeconfig.
    harness.go:278: Successful connection to cluster at: https://127.0.0.1:6443
    harness.go:363: running tests
    harness.go:75: going to run test suite with timeout of 2400 seconds for each step
    harness.go:375: testsuite: eager has 1 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/loading
=== PAUSE kuttl/harness/loading
=== CONT  kuttl/harness/loading
    case.go:346: stat /Users/kumarmallikarjuna/Workspace/oss/kuttl/lazy_test/eager/loading/test.kubeconfig: no such file or directory
=== NAME  kuttl
    harness.go:407: run tests finished
    harness.go:515: cleaning up
    harness.go:572: removing temp folder: ""
--- FAIL: kuttl (0.01s)
    --- FAIL: kuttl/harness (0.00s)
        --- FAIL: kuttl/harness/loading (0.00s)
FAIL
exit status 1
➜  lazy_test git:(tmp-kubeconfig-lazy-loading) ✗ go run ../cmd/kubectl-kuttl/main.go test lazy
2024/07/04 11:41:18 kutt-test config testdirs is overridden with args: [ lazy ]
=== RUN   kuttl
    harness.go:464: starting setup
    harness.go:255: running tests using configured kubeconfig.
    harness.go:278: Successful connection to cluster at: https://127.0.0.1:6443
    harness.go:363: running tests
    harness.go:75: going to run test suite with timeout of 2400 seconds for each step
    harness.go:375: testsuite: lazy has 1 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/loading
=== PAUSE kuttl/harness/loading
=== CONT  kuttl/harness/loading
    logger.go:42: 11:41:18 | loading | Creating namespace: kuttl-test-credible-crow
    case.go:400: failed in step 0-teststep
    case.go:402: failed to lazy-load kubeconfig: stat /Users/kumarmallikarjuna/Workspace/oss/kuttl/lazy_test/lazy/loading/test.kubeconfig: no such file or directory
    logger.go:42: 11:41:18 | loading | loading events from ns kuttl-test-credible-crow:
    logger.go:42: 11:41:18 | loading | Deleting namespace: kuttl-test-credible-crow
=== NAME  kuttl
    harness.go:407: run tests finished
    harness.go:515: cleaning up
    harness.go:572: removing temp folder: ""
--- FAIL: kuttl (5.14s)
    --- FAIL: kuttl/harness (0.00s)
        --- FAIL: kuttl/harness/loading (5.12s)
FAIL
exit status 1
```

Lazy-loading when the Kubeconfig exists and is same as the global Kubeconfig:
```shell
➜  lazy_test git:(main) ✗ go run ../cmd/kubectl-kuttl/main.go test eager
2024/07/04 11:37:44 kutt-test config testdirs is overridden with args: [ eager ]
=== RUN   kuttl
    harness.go:464: starting setup
    harness.go:255: running tests using configured kubeconfig.
    harness.go:278: Successful connection to cluster at: https://127.0.0.1:49639
    harness.go:363: running tests
    harness.go:75: going to run test suite with timeout of 2400 seconds for each step
    harness.go:375: testsuite: eager has 1 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/loading
=== PAUSE kuttl/harness/loading
=== CONT  kuttl/harness/loading
    case.go:344: stat /Users/kumarmallikarjuna/Workspace/oss/kuttl/lazy_test/eager/loading/test.kubeconfig: no such file or directory
=== NAME  kuttl
    harness.go:407: run tests finished
    harness.go:515: cleaning up
    harness.go:572: removing temp folder: ""
--- FAIL: kuttl (0.02s)
    --- FAIL: kuttl/harness (0.00s)
        --- FAIL: kuttl/harness/loading (0.00s)
FAIL
exit status 1
➜  lazy_test git:(main) ✗ go run ../cmd/kubectl-kuttl/main.go test lazy
2024/07/04 11:37:50 kutt-test config testdirs is overridden with args: [ lazy ]
=== RUN   kuttl
    harness.go:464: starting setup
    harness.go:255: running tests using configured kubeconfig.
    harness.go:278: Successful connection to cluster at: https://127.0.0.1:49639
    harness.go:363: running tests
    harness.go:75: going to run test suite with timeout of 2400 seconds for each step
    harness.go:375: testsuite: lazy has 1 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/loading
=== PAUSE kuttl/harness/loading
=== CONT  kuttl/harness/loading
    logger.go:42: 11:37:50 | loading | Ignoring test.kubeconfig as it does not match file name regexp: ^(\d+)-(?:[^\.]+)(?:\.yaml)?$
    logger.go:42: 11:37:50 | loading | Creating namespace: kuttl-test-needed-ox
    logger.go:42: 11:37:50 | loading | Creating namespace: kuttl-test-needed-ox
    logger.go:42: 11:37:50 | loading/0-teststep | starting test step 0-teststep
    logger.go:42: 11:37:50 | loading/0-teststep | running command: [sh -c echo hi]
    logger.go:42: 11:37:50 | loading/0-teststep | hi
    logger.go:42: 11:37:50 | loading/0-teststep | test step completed 0-teststep
    logger.go:42: 11:37:50 | loading | loading events from ns kuttl-test-needed-ox:
    logger.go:42: 11:37:50 | loading | Deleting namespace: kuttl-test-needed-ox
    logger.go:42: 11:37:55 | loading | Deleting namespace: kuttl-test-needed-ox
```