### PR TITLE
chore: fix bug label not being auto-added

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
 name: Bug report
 about: Report a bug encountered while operating KUTTL
-title: ''
-labels: kind/bug
-assignees: ''
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
 
 ---
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Looks like the label `kind/bug` doesn't exist which is causing the issues created as bugs not being assigned an appropriate label.

> Labels that will automatically be added to issues created with this template. If a label does not already exist in the repository, it will not be automatically added to the issue.

ref: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax.

This change uses the `bug` label which currently exists.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
