### PR TITLE
Make it possible to build with Go 1.23.

### DIFF
--- a/pkg/test/utils/testing.go
+++ b/pkg/test/utils/testing.go
@@ -116,6 +116,10 @@ func (testDeps) SnapshotCoverage() {
 
 }
 
+func (testDeps) InitRuntimeCoverage() (mode string, tearDown func(string, string) (string, error), snapcov func() float64) {
+	return
+}
+
 // corpusEntry is from the public go testing which references an internal structure.
 // corpusEntry is an alias to the same type as internal/fuzz.CorpusEntry.
 // We use a type alias because we don't want to export this type, and we can't


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

Paraphrasing the function doc:

> `MainStart` is not subject to the Go 1 compatibility document. It may change signature from release to release.

And so it did. This PR mimics what was done in https://github.com/hofstadter-io/hof/pull/392

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #546


This seems to work with both of:
```
[kuttl]$ GOTOOLCHAIN=go1.23rc2 go build ./...
[kuttl]$ GOTOOLCHAIN=go1.22 go build ./...
```