### PR TITLE
Bump go version to 1.22.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kudobuilder/kuttl
 
-go 1.22.0
-
-toolchain go1.22.1
+go 1.22.7
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1


### PR DESCRIPTION
**What this PR does / why we need it**:

Increase the minimum go version to 1.22.7 which includes some CVE fixes.

For context: we are building images with the github release binary and our image scanner picks up the CVEs.
