### PR TITLE
Allow for processing tls-server-name attribute in kubeconfig context

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -1290,6 +1290,7 @@ func Kubeconfig(cfg *rest.Config, w io.Writer) error {
 					Server:                   cfg.Host,
 					CertificateAuthorityData: cfg.TLSClientConfig.CAData,
 					InsecureSkipTLSVerify:    cfg.TLSClientConfig.Insecure,
+					TLSServerName:            cfg.TLSClientConfig.ServerName,
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #586 by allowing for processing of the `tls-server-name` attribute from the current kubecontext.

