### PR TITLE
chore: explicitly add quotes to error format

### DIFF
--- a/pkg/expressions/cel.go
+++ b/pkg/expressions/cel.go
@@ -134,7 +134,7 @@ func evaluateExpression(expr string,
 	}
 
 	if out.Value() != true {
-		return fmt.Errorf("expression %q evaluated to %q", expr, out.Value())
+		return fmt.Errorf("expression %q evaluated to '%v'", expr, out.Value())
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
The current format produces the output: `not all assertAll expressions evaluated to true: expression "<some-expression>" evaluated to %!q(bool=false)`. This change fixes the same.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
