### PR TITLE
feat: add as-groups as cli flag

### DIFF
--- a/pkg/kubernetes/config.go
+++ b/pkg/kubernetes/config.go
@@ -11,6 +11,7 @@ import (
 )
 
 var ImpersonateAs = ""
+var ImpersonateAsGroups = []string{}
 
 func GetConfig() (*rest.Config, error) {
 	cfg, err := config.GetConfig()
@@ -20,6 +21,10 @@ func GetConfig() (*rest.Config, error) {
 
 	if ImpersonateAs != "" {
 		cfg.Impersonate.UserName = ImpersonateAs
+	}
+
+	if len(ImpersonateAsGroups) != 0 {
+		cfg.Impersonate.Groups = ImpersonateAsGroups
 	}
 
 	return cfg, nil

--- a/pkg/kuttlctl/cmd/root.go
+++ b/pkg/kuttlctl/cmd/root.go
@@ -32,6 +32,8 @@ and serves as an API aggregation layer.
 	}
 
 	cmd.PersistentFlags().StringVar(&kubernetes.ImpersonateAs, "as", "", "Username to impersonate for the operation. User could be a regular user or a service account in a namespace.")
+	cmd.PersistentFlags().StringSliceVar(&kubernetes.ImpersonateAsGroups, "as-groups", []string{}, "Groups to impersonate for the operation.")
+
 	cmd.AddCommand(newAssertCmd())
 	cmd.AddCommand(newErrorsCmd())
 	cmd.AddCommand(newTestCmd())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

Adding impersonation via Flag, it's a bit easier than having to manage n-kubeconfigs are always rewriting the kubeconfig. My cases require to always change the impersonation. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
