### PR TITLE
chore: bump golang builder image and kubectl versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # artifacts by default will land in the root of the mount point.
 
 # kuttl builder
-FROM golang:1.21 as builder
+FROM golang:1.23 as builder
 
 WORKDIR /go/src/kuttl
 COPY . .
@@ -31,8 +31,8 @@ LABEL org.opencontainers.image.source="https://github.com/kudobuilder/kuttl"
 RUN microdnf install vim tar gzip
 RUN echo 'alias vi=vim' >> ~/.bashrc
 
-#  kube 1.26
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.26.0/bin/linux/amd64/kubectl
+#  kube 1.31
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.31.0/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I tried to build a docker image with the given Dockerfile and got the following error:

<img width="795" height="64" alt="image" src="https://github.com/user-attachments/assets/f59155b3-4624-48f9-8437-1309814b462f" />

Hence, i'd like to bump the version of the golang build image and as the official support for k8s v1.26 ended in DEC 2023 i'd also like to bump kubectl to v1.31.
