### PR TITLE
chore: run tests in non-verbose mode by default

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -19,4 +19,4 @@ jobs:
         go-version: 1.21
     - uses: actions/checkout@v2.4.0
     - name: "Run end-to-end tests"
-      run: make e2e-test
+      run: make e2e-test TEST_FLAGS=-v

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,4 +19,4 @@ jobs:
         go-version: 1.21
     - uses: actions/checkout@v2.4.0
     - name: "Run integration tests"
-      run: make integration-test INTEGRATION_OUTPUT_JUNIT="true"
+      run: make integration-test INTEGRATION_OUTPUT_JUNIT="true" TEST_FLAGS=-v

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -19,4 +19,4 @@ jobs:
         go-version: 1.21
     - uses: actions/checkout@v2.4.0
     - name: "Run unit tests"
-      run: make test
+      run: make test TEST_FLAGS=-v

--- a/Makefile
+++ b/Makefile
@@ -131,15 +131,15 @@ all: lint test integration-test e2e-test  ## Runs lint, unit, integration and e2
 test: ## Runs unit tests
 ifdef _INTELLIJ_FORCE_SET_GOFLAGS
 # Run tests from a Goland terminal. Goland already set '-mod=readonly'
-	go test ./pkg/... ./internal/...  -v -coverprofile cover.out
+	go test ./pkg/... ./internal/... -coverprofile cover.out $(TEST_FLAGS)
 else
-	go test ./pkg/... ./internal/... -v -mod=readonly -coverprofile cover.out
+	go test ./pkg/... ./internal/... -mod=readonly -coverprofile cover.out $(TEST_FLAGS)
 endif
 
 .PHONY: integration-test
 # Run integration tests
 integration-test: envtest  ## Runs integration tests
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" ./hack/run-integration-tests.sh
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" ./hack/run-integration-tests.sh $(TEST_FLAGS)
 
 .PHONY: e2e-test
 # Run e2e tests

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -14,8 +14,8 @@ then
     go get github.com/jstemmer/go-junit-report
     go install github.com/jstemmer/go-junit-report
     go mod tidy
-    go test -tags integration ./pkg/... ./internal/... -v -mod=readonly -coverprofile cover-integration.out 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > reports/integration_report.xml
+    go test -tags integration ./pkg/... ./internal/... -mod=readonly -coverprofile cover-integration.out "$@" 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > reports/integration_report.xml
 else
     echo "Running integration tests without junit output"
-    go test -tags integration ./pkg/... ./internal/... -v -mod=readonly -coverprofile cover-integration.out
+    go test -tags integration ./pkg/... ./internal/... -mod=readonly -coverprofile cover-integration.out "$@"
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

It's really annoying to have to search for `FAILED:` in the long output when just one test case fails. Especially now that one fails in my environment every time due to https://github.com/kubernetes-sigs/kind/issues/3795#issuecomment-2500048284

Adds `$TEST_FLAGS` to make sure output in CI is unchanged.