### PR TITLE
chore: update goreleaser config to 2.15.2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ builds:
       - s390x
 archives:
   - id: kubectl-kuttl-tarball
-    builds:
+    ids:
       - kubectl-kuttl
     # Based on the default name_template with addition of arch replacements
     # See https://goreleaser.com/customization/archive/#archives
@@ -40,9 +40,9 @@ archives:
       {{- with .Arm }}v{{ . }}{{ end }}
       {{- with .Mips }}_{{ . }}{{ end }}
       {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
-    format: tar.gz
+    formats: ["tar.gz"]
   - id: binaries
-    builds:
+    ids:
       - manager
       - kubectl-kuttl
     # Based on the default name_template with addition of arch replacements
@@ -57,8 +57,8 @@ archives:
       {{- with .Arm }}v{{ . }}{{ end }}
       {{- with .Mips }}_{{ . }}{{ end }}
       {{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
-    format: binary
-brews:
+    formats: ["binary"]
+homebrew_casks:
   - name: kuttl-cli
     ids:
       - kubectl-kuttl-tarball
@@ -69,13 +69,16 @@ brews:
       name: kudoreleasebot
       email: release@kudo.dev
     skip_upload: auto
-    directory: Formula
     homepage: https://github.com/kudobuilder/kuttl
     description: Interact with KUTTL via the kubectl plugin
     dependencies:
-      - kubernetes-cli
-    install: |
-      bin.install "kubectl-kuttl"
+      - formula: kubernetes-cli
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/kubectl-kuttl"]
+          end
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,6 +60,8 @@ archives:
     formats: ["binary"]
 homebrew_casks:
   - name: kuttl-cli
+    binaries:
+      - kubectl-kuttl
     ids:
       - kubectl-kuttl-tarball
     repository:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
```
[kuttl]$ goreleaser healthcheck
  • checking tools...
  • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
  • DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
  • brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info
    • ✓ git
    • ✓ go
    • done!
  • thanks for using GoReleaser!
```