### PR TITLE
fix: add random suffix to namespace name to prevent collisions

### DIFF
--- a/internal/testcase/case.go
+++ b/internal/testcase/case.go
@@ -15,6 +15,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -149,7 +150,7 @@ func NewCase(name string, parentPath string, options ...CaseOption) *Case {
 
 	if c.ns == nil {
 		c.ns = &namespace{
-			name:         fmt.Sprintf("kuttl-test-%s", petname.Generate(2, "-")),
+			name:         fmt.Sprintf("kuttl-%s-%s", petname.Generate(2, "-"), utilrand.String(4)),
 			userSupplied: false,
 		}
 	}


### PR DESCRIPTION
Append a 4-character random suffix to the generated namespace name and drop the `test-` infix to keep the max length unchanged.

    Old format: kuttl-test-<adjective>-<noun>
    New format: kuttl-<adjective>-<noun>-<4 char suffix>
    Example:    kuttl-enormous-termite-x7kg

This increases the namespace space from ~200k to ~40 billion combinations, making collisions statistically negligible even at high parallelism.

Fixes https://github.com/kudobuilder/kuttl/issues/500.
