### PR TITLE
fix: randomize namespace in TestStepDeleteExistingLabelMatch to prevent -count flake

### DIFF
--- a/internal/step/step_integration_test.go
+++ b/internal/step/step_integration_test.go
@@ -233,7 +233,7 @@ func TestCheckResourceIntegration(t *testing.T) {
 
 // Verify that the DeleteExisting method properly cleans up resources that are matched on labels during a test step.
 func TestStepDeleteExistingLabelMatch(t *testing.T) {
-	namespace := "world"
+	namespace := fmt.Sprintf("kuttl-test-%s", petname.Generate(2, "-"))
 
 	podSpec := map[string]interface{}{
 		"containers": []interface{}{
@@ -244,15 +244,15 @@ func TestStepDeleteExistingLabelMatch(t *testing.T) {
 		},
 	}
 
-	podToDelete := kubernetes.WithSpec(t, kubernetes.WithLabels(t, kubernetes.NewPod("aa-delete-me", "world"), map[string]string{
+	podToDelete := kubernetes.WithSpec(t, kubernetes.WithLabels(t, kubernetes.NewPod("aa-delete-me", namespace), map[string]string{
 		"hello": "world",
 	}), podSpec)
 
-	podToKeep := kubernetes.WithSpec(t, kubernetes.WithLabels(t, kubernetes.NewPod("bb-dont-delete-me", "world"), map[string]string{
+	podToKeep := kubernetes.WithSpec(t, kubernetes.WithLabels(t, kubernetes.NewPod("bb-dont-delete-me", namespace), map[string]string{
 		"bye": "moon",
 	}), podSpec)
 
-	podToDelete2 := kubernetes.WithSpec(t, kubernetes.WithLabels(t, kubernetes.NewPod("cc-delete-me", "world"), map[string]string{
+	podToDelete2 := kubernetes.WithSpec(t, kubernetes.WithLabels(t, kubernetes.NewPod("cc-delete-me", namespace), map[string]string{
 		"hello": "world",
 	}), podSpec)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`TestStepDeleteExistingLabelMatch` hardcoded its namespace as `"world"`. Under `go test -count N` the integration suite reuses the same envtest control plane across iterations, so the second iteration failed with `namespaces "world" already exists`.

This randomizes the namespace per run with `fmt.Sprintf("kuttl-test-%s", petname.Generate(2, "-"))`, the same pattern the sibling tests in this file already use. The delete-by-label match semantics (`hello=world` deleted, `bye=moon` kept) are unchanged.

Validation (local):
- `make integration-test TEST_FLAGS="-run TestStepDeleteExistingLabelMatch -count=100 -v"`: 100/100 PASS, each run uses a unique namespace
- `gofmt` clean, `go vet -tags integration` clean
- `golangci-lint --build-tags integration --new-from-rev=upstream/main`: 0 new issues

Fixes #647