### PR TITLE
chore(tests): tell setup-envtest to use any k8s patch version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ LDFLAGS := -X ${GIT_VERSION_PATH}=${GIT_VERSION} -X ${GIT_COMMIT_PATH}=${GIT_COM
 # Please update the list of linters in .golagci.yml when bumping the version.
 GOLANGCI_LINT_VER = 2.11.4
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-# Dynamically derived from the k8s.io/api dependency version in go.mod (v0.X.Y -> 1.X.Y).
-ENVTEST_K8S_VERSION ?= $(shell go list -m -f '{{.Version}}' k8s.io/api | sed 's/^v0\./1./')
+# Dynamically derived from the k8s.io/api dependency version in go.mod (v0.X.Y -> 1.X),
+# since not all patch versions are re-published.
+ENVTEST_K8S_VERSION ?= $(shell go list -m -f '{{.Version}}' k8s.io/api | sed 's/^v0\.\([0-9]*\).*/1.\1/')
 
 export GO111MODULE=on
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependabot [PRs bumping k8s deps](https://github.com/kudobuilder/kuttl/pull/693) are failing with:

```
Using 1.36.2 k8s binaries...
unable to fetch hash for requested version: unable to find archive for 1.36.2 (linux,amd64)
```

because the controller-runtime project [does not republish all versions](https://kubernetes.slack.com/archives/C02MRBMN00Z/p1781523355889079?thread_ts=1781508035.623429&cid=C02MRBMN00Z).

From our PoV it's enough to specify the minor version.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
