### PR TITLE
fix(test): use require.NoError for envtest startup in TestAssertExpressions

### DIFF
--- a/internal/step/expression_integration_test.go
+++ b/internal/step/expression_integration_test.go
@@ -15,6 +15,7 @@ import (
 	kfile "github.com/kudobuilder/kuttl/internal/file"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +45,7 @@ func TestAssertExpressions(t *testing.T) {
 	defer cancel()
 
 	testenv, err := kubernetes.StartTestEnvironment(false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	codednsDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Motivation:
TestAssertExpressions occasionally fails in CI with a nil pointer
dereference panic instead of a clean test failure. When
kubernetes.StartTestEnvironment fails to start the envtest control
plane (e.g. "timeout waiting for process kube-apiserver to start
successfully"), it returns a zero-value TestEnvironment whose Client
field is a nil interface. The test used assert.NoError on that error,
which records a failure but does not stop execution, so the test went
on to call testenv.Client.Create(...) on the nil Client and panicked
with "runtime error: invalid memory address or nil pointer
dereference" — the exact signature reported in #648.

Approach:
Change assert.NoError to require.NoError for the StartTestEnvironment
error, matching the convention already used everywhere else in the
repo for this exact call (internal/testcase/case_integration_test.go,
internal/step/step_integration_test.go's TestMain,
internal/harness/harness_integration_test.go, and
internal/kubernetes/retry_client_integration_test.go all halt
immediately on this error). This does not change any cleanup
behavior: the function registers no defer for testenv before this
call.

Note this does not fix the underlying envtest control-plane startup
flakiness (a separate, environment-level issue); it only ensures that
when startup does fail, the test reports a clean, diagnostic failure
instead of a nil-pointer panic that can obscure the real error and
crash the test binary before other subtests get to run.

Validation:
- go build ./...
- go vet -tags integration ./internal/step/...
- KUBEBUILDER_ASSETS=<envtest 1.36.2 assets> go test -tags integration
  ./internal/step/... -run TestAssertExpressions -v (all subtests pass)
- KUBEBUILDER_ASSETS=<envtest 1.36.2 assets> go test -tags integration
  ./internal/step/... -v (full package suite passes)
- Reproduced the exact panic signature from #648 in an isolated
  scratch repro mirroring this file's original assert.NoError +
  testenv.Client dereference pattern, confirmed it panics with
  "invalid memory address or nil pointer dereference [recovered,
  repanicked]", then confirmed the require.NoError pattern instead
  fails cleanly with no panic, only the real underlying error message.

Fixes #648

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>